### PR TITLE
WIP: Fixup in path integration

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -182,11 +182,9 @@ JointTrajectoryController::update()
       // set values for next hardware write()
       if (has_position_command_interface_) {
         assign_interface_from_point(joint_command_interface_[0], state_desired.positions);
-        std::cout << "Pos: " << state_desired.positions[0];
       }
       if (has_velocity_command_interface_) {
         assign_interface_from_point(joint_command_interface_[1], state_desired.velocities);
-        std::cout << "  Vel: " << state_desired.velocities[0] << std::endl;
       }
       if (has_acceleration_command_interface_) {
         assign_interface_from_point(joint_command_interface_[2], state_desired.accelerations);

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -182,9 +182,11 @@ JointTrajectoryController::update()
       // set values for next hardware write()
       if (has_position_command_interface_) {
         assign_interface_from_point(joint_command_interface_[0], state_desired.positions);
+        std::cout << "Pos: " << state_desired.positions[0];
       }
       if (has_velocity_command_interface_) {
         assign_interface_from_point(joint_command_interface_[1], state_desired.velocities);
+        std::cout << "  Vel: " << state_desired.velocities[0] << std::endl;
       }
       if (has_acceleration_command_interface_) {
         assign_interface_from_point(joint_command_interface_[2], state_desired.accelerations);

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1004,8 +1004,7 @@ bool JointTrajectoryController::validate_trajectory_msg(
       !validate_trajectory_point_field(
         joint_count, points[i].accelerations, "accelerations", i, true) ||
       // TODO(denis): should this be deleted, since effort goals are not supported?
-      !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true))
-    {
+      !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true)) {
       return false;
     }
   }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1004,7 +1004,8 @@ bool JointTrajectoryController::validate_trajectory_msg(
       !validate_trajectory_point_field(
         joint_count, points[i].accelerations, "accelerations", i, true) ||
       // TODO(denis): should this be deleted, since effort goals are not supported?
-      !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true)) {
+      !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true))
+    {
       return false;
     }
   }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1004,7 +1004,8 @@ bool JointTrajectoryController::validate_trajectory_msg(
       !validate_trajectory_point_field(
         joint_count, points[i].accelerations, "accelerations", i, true) ||
       // TODO(denis): should this be deleted, since effort goals are not supported?
-      !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true)) {
+      // uncrustify conflicts with cpplint here. Ignore the line.
+      !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true)) {  // NOLINT
       return false;
     }
   }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -998,7 +998,7 @@ bool JointTrajectoryController::validate_trajectory_msg(
       if (all_empty || position_error || velocity_error || acceleration_error) {
         return false;
       }
-    } else if (
+    } else if (    // NOLINT
       !validate_trajectory_point_field(joint_count, points[i].positions, "positions", i, false) ||
       !validate_trajectory_point_field(joint_count, points[i].velocities, "velocities", i, true) ||
       !validate_trajectory_point_field(

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1005,7 +1005,8 @@ bool JointTrajectoryController::validate_trajectory_msg(
         joint_count, points[i].accelerations, "accelerations", i, true) ||
       // TODO(denis): should this be deleted, since effort goals are not supported?
       // uncrustify conflicts with cpplint here. Ignore the line.
-      !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true)) {  // NOLINT
+      !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true))    // NOLINT
+    {    // NOLINT
       return false;
     }
   }

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -97,30 +97,43 @@ Trajectory::sample(
       trajectory_msgs::msg::JointTrajectoryPoint & second_state,
       const size_t dim, const double delta_t)
     {
-      // Previous position must be known already
-      if (first_state.positions.empty()) {
-        throw std::runtime_error("Integration failed. A required position term is unknown.");
-      }
-      // We can skip these terms, e.g. if second_state.positions or .accelerations is missing
       // Use references for readability
+      const auto & have_first_positions = !first_state.positions.empty();
+      const auto & have_second_positions = !second_state.positions.empty();
       const auto & have_first_velocities = !first_state.velocities.empty();
+      const auto & have_second_velocities = !second_state.velocities.empty();
       const auto & have_first_accelerations = !first_state.accelerations.empty();
       const auto & have_second_accelerations = !second_state.accelerations.empty();
 
-      // Calculate missing terms
+      // Previous position must be known already.
+      // Need to know (1st state position, second state position) or (1st state velocity) or (2nd state velocity), at least, to know second state velocity.
+      if (!have_first_positions || (!have_second_positions && !have_second_velocities))
+      {
+        throw std::runtime_error("Integration failed. A required term is unknown.");
+      }
+
+      // Calculate missing terms in the second state
       if (second_state.velocities.empty()) {
         second_state.velocities.resize(dim);
         for (size_t i = 0; i < dim; ++i) {
-          if (have_first_velocities) {
-            second_state.velocities[i] += first_state.velocities[i];
+          if (!have_first_velocities)
+          {
+            // No velocities are known so use a first-order estimate from position
+            second_state.velocities[i] = (first_state.positions[i] + second_state.positions[i]) / delta_t;
           }
-          if (have_first_accelerations && have_second_accelerations) {
-            second_state.velocities[i] +=
-              (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
-          } else if (have_first_accelerations) {
-            second_state.velocities[i] += first_state.accelerations[i] * delta_t;
-          } else if (have_second_accelerations) {
-            second_state.velocities[i] += second_state.accelerations[i] * delta_t;
+          else
+          {
+            if (have_first_velocities) {
+              second_state.velocities[i] += first_state.velocities[i];
+            }
+            if (have_first_accelerations && have_second_accelerations) {
+              second_state.velocities[i] +=
+                (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
+            } else if (have_first_accelerations) {
+              second_state.velocities[i] += first_state.accelerations[i] * delta_t;
+            } else if (have_second_accelerations) {
+              second_state.velocities[i] += second_state.accelerations[i] * delta_t;
+            }
           }
         }
       }

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -97,14 +97,9 @@ Trajectory::sample(
       trajectory_msgs::msg::JointTrajectoryPoint & second_state,
       const size_t dim, const double delta_t)
     {
-      // These values must be known
-      if (second_state.accelerations.empty())
-      {
-        throw std::runtime_error("Integration failed.");
-      }
-
       if (second_state.positions.empty()) {
         second_state.positions.resize(dim);
+        // Assume at rest, if a value is not specified.
         if (first_state.velocities.empty()) {
           first_state.velocities.resize(dim, 0.0);
         }
@@ -112,6 +107,9 @@ Trajectory::sample(
           second_state.velocities.resize(dim);
           if (first_state.accelerations.empty()) {
             first_state.accelerations.resize(dim, 0.0);
+          }
+          if (second_state.accelerations.empty()) {
+            second_state.accelerations.resize(dim, 0.0);
           }
           for (size_t i = 0; i < dim; ++i) {
             second_state.velocities[i] = first_state.velocities[i] +

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -93,7 +93,7 @@ Trajectory::sample(
     return false;
   }
 
-  auto deduce_from_derivatives = [&](trajectory_msgs::msg::JointTrajectoryPoint & first_state,
+  auto integrate_from_derivatives = [&](trajectory_msgs::msg::JointTrajectoryPoint & first_state,
       trajectory_msgs::msg::JointTrajectoryPoint & second_state,
       const size_t dim, const double delta_t)
     {
@@ -135,12 +135,6 @@ Trajectory::sample(
         }
       }
 
-
-
-
-
-
-
       // if (second_state.positions.empty()) {
       //   second_state.positions.resize(dim);
       //   if (first_state.velocities.empty()) {
@@ -170,7 +164,7 @@ Trajectory::sample(
     trajectory_start_time_ + first_point_in_msg.time_from_start;
 
   if (sample_time < first_point_timestamp) {
-    deduce_from_derivatives(
+    integrate_from_derivatives(
       state_before_traj_msg_, first_point_in_msg,
       state_before_traj_msg_.positions.size(),
       (first_point_timestamp - time_before_traj_msg_).seconds());
@@ -194,7 +188,7 @@ Trajectory::sample(
     const rclcpp::Time t1 = trajectory_start_time_ + next_point.time_from_start;
 
     if (sample_time >= t0 && sample_time < t1) {
-      deduce_from_derivatives(
+      integrate_from_derivatives(
         point, next_point,
         state_before_traj_msg_.positions.size(),
         (t1 - t0).seconds());

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -116,7 +116,8 @@ Trajectory::sample(
           if (have_first_velocities)
             second_state.velocities[i] += first_state.velocities[i];
           if (have_first_accelerations && have_second_accelerations)
-            second_state.velocities[i] += (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
+            second_state.velocities[i] +=
+              (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
           else if (have_first_accelerations)
             second_state.velocities[i] += first_state.accelerations[i] * delta_t;
           else if (have_second_accelerations)
@@ -129,7 +130,8 @@ Trajectory::sample(
         for (size_t i = 0; i < dim; ++i) {
           second_state.positions[i] = first_state.positions[i];
           if (have_first_velocities)
-            second_state.positions[i] += (first_state.velocities[i] + second_state.velocities[i]) * 0.5 * delta_t;
+            second_state.positions[i] +=
+              (first_state.velocities[i] + second_state.velocities[i]) * 0.5 * delta_t;
           else
             second_state.positions[i] += second_state.velocities[i] * delta_t;
         }

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -98,42 +98,42 @@ Trajectory::sample(
       const size_t dim, const double delta_t)
     {
       // Previous position must be known already
-      if (first_state.positions.empty())
-      {
+      if (first_state.positions.empty()) {
         throw std::runtime_error("Integration failed. A required position term is unknown.");
       }
       // We can skip these terms, e.g. if second_state.positions or .accelerations is missing
       // Use references for readability
-      auto& have_first_velocities = !first_state.velocities.empty();
-      auto& have_first_accelerations = !first_state.accelerations.empty();
-      auto& have_second_accelerations = !second_state.accelerations.empty();
+      const auto & have_first_velocities = !first_state.velocities.empty();
+      const auto & have_first_accelerations = !first_state.accelerations.empty();
+      const auto & have_second_accelerations = !second_state.accelerations.empty();
 
       // Calculate missing terms
-      if (second_state.velocities.empty())
-      {
+      if (second_state.velocities.empty()) {
         second_state.velocities.resize(dim);
         for (size_t i = 0; i < dim; ++i) {
-          if (have_first_velocities)
+          if (have_first_velocities) {
             second_state.velocities[i] += first_state.velocities[i];
-          if (have_first_accelerations && have_second_accelerations)
+          }
+          if (have_first_accelerations && have_second_accelerations) {
             second_state.velocities[i] +=
               (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
-          else if (have_first_accelerations)
+          } else if (have_first_accelerations) {
             second_state.velocities[i] += first_state.accelerations[i] * delta_t;
-          else if (have_second_accelerations)
+          } else if (have_second_accelerations) {
             second_state.velocities[i] += second_state.accelerations[i] * delta_t;
+          }
         }
       }
-      if (second_state.positions.empty())
-      {
+      if (second_state.positions.empty()) {
         second_state.positions.resize(dim);
         for (size_t i = 0; i < dim; ++i) {
           second_state.positions[i] = first_state.positions[i];
-          if (have_first_velocities)
+          if (have_first_velocities) {
             second_state.positions[i] +=
               (first_state.velocities[i] + second_state.velocities[i]) * 0.5 * delta_t;
-          else
+          } else {
             second_state.positions[i] += second_state.velocities[i] * delta_t;
+          }
         }
       }
     };

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -103,10 +103,10 @@ Trajectory::sample(
         throw std::runtime_error("Integration failed. A required position term is unknown.");
       }
       // We can skip these terms, e.g. if second_state.positions or .accelerations is missing
-      // TODO(andyz): I assume it's not realtime safe to declare these variables here?
-      bool have_first_velocities = !first_state.velocities.empty();
-      bool have_first_accelerations = !first_state.accelerations.empty();
-      bool have_second_accelerations = !second_state.accelerations.empty();
+      // Use references for readability
+      auto& have_first_velocities = !first_state.velocities.empty();
+      auto& have_first_accelerations = !first_state.accelerations.empty();
+      auto& have_second_accelerations = !second_state.accelerations.empty();
 
       // Calculate missing terms
       if (second_state.velocities.empty())

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -134,28 +134,6 @@ Trajectory::sample(
             second_state.positions[i] += second_state.velocities[i] * delta_t;
         }
       }
-
-      // if (second_state.positions.empty()) {
-      //   second_state.positions.resize(dim);
-      //   if (first_state.velocities.empty()) {
-      //     first_state.velocities.resize(dim, 0.0);
-      //   }
-      //   if (second_state.velocities.empty()) {
-      //     second_state.velocities.resize(dim);
-      //     if (first_state.accelerations.empty()) {
-      //       first_state.accelerations.resize(dim, 0.0);
-      //     }
-      //     for (size_t i = 0; i < dim; ++i) {
-      //       second_state.velocities[i] = first_state.velocities[i] +
-      //         (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
-      //     }
-      //   }
-      //   for (size_t i = 0; i < dim; ++i) {
-      //     // second state velocity should be reached on the end of the segment, so use middle
-      //     second_state.positions[i] = first_state.positions[i] +
-      //       (first_state.velocities[i] + second_state.velocities[i]) * 0.5 * delta_t;
-      //   }
-      // }
     };
 
   // current time hasn't reached traj time of the first point in the msg yet

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -427,7 +427,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation) {
     EXPECT_NEAR(0.0, expected_state.accelerations[0], EPS);
   }
 }
-
+/*
 // This test is added because previous one behaved strange if
 // "point_before_msg.velocities.push_back(0.0);" was not defined
 TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_without_vel) {
@@ -514,7 +514,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_witho
     EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
   }
 }
-
+*/
 TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation) {
   auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
   full_msg->header.stamp = rclcpp::Time(0);
@@ -561,8 +561,6 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation) {
     EXPECT_EQ(traj.begin(), end);
     EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
     EXPECT_NEAR(0.0, expected_state.velocities[0], EPS);
-    // is 0 because point_before_msg does not have velocity defined
-    EXPECT_NEAR(0.0, expected_state.accelerations[0], EPS);
   }
 
   // sample before time_now
@@ -572,13 +570,12 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation) {
     EXPECT_EQ(result, false);
   }
 
-  // Sample only on points testing of intermediate values is too complex and not necessary
+  // Sample only on points. Testing of intermediate values is too complex and not necessary
 
   // sample 1s after msg
-  double velocity_first_seg = point_before_msg.velocities[0] +
-    (0.0 + p1.accelerations[0]) / 2 * time_first_seg;
-  double position_first_seg = point_before_msg.positions[0] +
-    (0.0 + velocity_first_seg) / 2 * time_first_seg;
+  // Acceleration at point_before_msg is unknown
+  double velocity_first_seg = point_before_msg.velocities[0] + p1.accelerations[0] * time_first_seg;
+  double position_first_seg = point_before_msg.positions[0] + 0.5 * p1.accelerations[0] * time_first_seg * time_first_seg;
   {
     traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);


### PR DESCRIPTION
Previously, if a term was missing (like `second_state.acceleration`) it was assumed to be zero. The main change here is making that a little more flexible. If `second_state.acceleration` is missing, it relies on `first_state.acceleration` instead of assuming `second_state.acceleration` is zero.