### PR TITLE
Delete unused frames

### DIFF
--- a/admittance_controller/include/admittance_controller/admittance_rule.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule.hpp
@@ -89,11 +89,8 @@ public:
   // IK related parameters
   // ik_base_frame should be stationary so vel/accel calculations are correct
   std::string ik_base_frame_;
-  std::string ik_tip_frame_;
   std::string ik_group_name_;
 
-  // Frame which position should be controlled
-  std::string endeffector_frame_;
   // Admittance calcs (displacement etc) are done in this frame. Usually the tool or end-effector
   std::string control_frame_;
   // Gravity points down (neg. Z) in the world frame
@@ -150,15 +147,12 @@ protected:
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
-  tf2::Transform ik_tip_to_control_frame_tf_;
-  tf2::Transform control_frame_to_ik_tip_tf_;
-
   // measured_wrench_ could arrive in any frame. It will be transformed
   geometry_msgs::msg::WrenchStamped measured_wrench_;
   geometry_msgs::msg::WrenchStamped measured_wrench_filtered_;
 
   geometry_msgs::msg::WrenchStamped measured_wrench_ik_base_frame_;
-  geometry_msgs::msg::WrenchStamped measured_wrench_endeffector_frame_;
+  geometry_msgs::msg::WrenchStamped measured_wrench_control_frame_;
 
   geometry_msgs::msg::PoseStamped current_pose_ik_base_frame_;
 

--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -171,9 +171,6 @@ controller_interface::return_type AdmittanceRule::configure(rclcpp::Node::Shared
   // Initialize variables used in the update loop
   measured_wrench_.header.frame_id = sensor_frame_;
 
-  relative_admittance_pose_.header.frame_id = control_frame_;
-  relative_admittance_pose_.child_frame_id = control_frame_;
-
   reference_joint_deltas_vec_.reserve(6);
   reference_deltas_vec_ik_base_.reserve(6);
   reference_deltas_ik_base_.header.frame_id = ik_base_frame_;

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -153,9 +153,7 @@ CallbackReturn AdmittanceController::on_configure(
     get_bool_param_and_error_if_empty(use_joint_commands_as_input_, "use_joint_commands_as_input") ||
     get_bool_param_and_error_if_empty(admittance_->open_loop_control_, "open_loop_control") ||
     get_string_param_and_error_if_empty(admittance_->ik_base_frame_, "IK.base") ||
-    get_string_param_and_error_if_empty(admittance_->ik_tip_frame_, "IK.tip") ||
     get_string_param_and_error_if_empty(admittance_->ik_group_name_, "IK.group_name") ||
-    get_string_param_and_error_if_empty(admittance_->endeffector_frame_, "endeffector_frame") ||
     get_string_param_and_error_if_empty(admittance_->control_frame_, "control_frame") ||
     get_string_param_and_error_if_empty(admittance_->fixed_world_frame_, "fixed_world_frame") ||
     get_string_param_and_error_if_empty(admittance_->sensor_frame_, "sensor_frame") ||

--- a/admittance_controller/test/test_admittance_controller.cpp
+++ b/admittance_controller/test/test_admittance_controller.cpp
@@ -211,7 +211,6 @@ TEST_F(AdmittanceControllerTest, all_parameters_set_configure_success)
 
   ASSERT_EQ(controller_->ft_sensor_name_, ft_sensor_name_);
   ASSERT_EQ(controller_->admittance_->ik_base_frame_, ik_base_frame_);
-  ASSERT_EQ(controller_->admittance_->ik_tip_frame_, ik_tip_frame_);
   //   ASSERT_EQ(controller_->admittance_->ik_group_name_, ik_group_name_);
   ASSERT_EQ(controller_->admittance_->fixed_world_frame_, fixed_world_frame_);
   ASSERT_EQ(controller_->admittance_->sensor_frame_, sensor_frame_);


### PR DESCRIPTION
These frames are either completely unused or only used in reporting a status message. Let's delete them for now. I know we _might_ need to reimplement some of them to handle different tool transforms later.

Merge with (https://github.com/SchillingRobotics/schilling_manipulators/pull/287) to avoid build errors.