### PR TITLE
Add dynamic admittance parameters

### DIFF
--- a/admittance_controller/include/admittance_controller/admittance_controller.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_controller.hpp
@@ -88,6 +88,9 @@ protected:
   std::unique_ptr<admittance_controller::AdmittanceRule> admittance_;
   rclcpp::Time previous_time_;
 
+  // Callback for updating dynamic parameters
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_callback_handle_;
+
   // Command subscribers and Controller State publisher
   using ControllerCommandWrenchMsg = geometry_msgs::msg::WrenchStamped;
   using ControllerCommandPoseMsg = geometry_msgs::msg::PoseStamped;

--- a/admittance_controller/include/admittance_controller/admittance_controller_cartesian_commands.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_controller_cartesian_commands.hpp
@@ -1,0 +1,41 @@
+
+// Header!!
+std::string ik_tip_frame_;
+
+// Frame which position should be controlled
+std::string endeffector_frame_;
+
+tf2::Transform ik_tip_to_control_frame_tf_;
+tf2::Transform control_frame_to_ik_tip_tf_;
+
+// CPP!!
+controller_interface::return_type AdmittanceRule::reset()
+{
+  // Initialize ik_tip and tool_frame transformations - those are fixed transformations
+  tf2::Stamped<tf2::Transform> tf2_transform;
+  try {
+    auto transform = tf_buffer_->lookupTransform(ik_tip_frame_, control_frame_, tf2::TimePointZero);
+    tf2::fromMsg(transform, tf2_transform);
+    ik_tip_to_control_frame_tf_ = tf2_transform;
+    control_frame_to_ik_tip_tf_ = tf2_transform.inverse();
+  } catch (const tf2::TransformException & e) {
+    RCLCPP_ERROR_SKIPFIRST_THROTTLE(
+      rclcpp::get_logger("AdmittanceRule"), *clock_, 5000, "%s", e.what());
+    return controller_interface::return_type::ERROR;
+  }
+}
+
+
+controller_interface::return_type AdmittanceRule::get_controller_state(
+  control_msgs::msg::AdmittanceControllerState & state_message)
+{
+  // FIXME(destogl): Something is wrong with this transformation - check frames...
+  try {
+    auto transform = tf_buffer_->lookupTransform(endeffector_frame_, control_frame_, tf2::TimePointZero);
+    tf2::doTransform(measured_wrench_ik_base_frame_, measured_wrench_endeffector_frame_, transform);
+  } catch (const tf2::TransformException & e) {
+    RCLCPP_ERROR_SKIPFIRST_THROTTLE(
+      rclcpp::get_logger("AdmittanceRule"), *clock_, 5000, "%s", e.what());
+  }
+  state_message.measured_wrench_endeffector_frame = measured_wrench_endeffector_frame_;
+}

--- a/admittance_controller/include/admittance_controller/admittance_rule.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule.hpp
@@ -267,87 +267,6 @@ public:
   std::array<double, 6> stiffness_;
 };
 
-struct DynamicAdmittanceParameters
-{
-public:
-  // Reconfigure updated parameters
-  bool update(std::shared_ptr<rclcpp::Node> node)
-  {
-    // Check for updated selected_axes_
-    std::map<std::string, std::pair<bool, bool>>::iterator axes_iterator;
-    for (axes_iterator = selected_axes_map_.begin(); axes_iterator != selected_axes_map_.end();
-         ++axes_iterator) {
-      // If parameter got changed, update configuration
-      if (axes_iterator->second.second) {
-        axes_iterator->second.first = node->get_parameter(axes_iterator->first).get_value<bool>();
-        RCLCPP_INFO(node->get_logger(),
-          "Successfully updated param '%s', new value: '%d'", axes_iterator->first.c_str(), axes_iterator->second.first);
-
-        axes_iterator->second.second = false;
-      }
-    }
-    // Check for updated mass, stiffness, damping or damping_ratio values
-    std::map<std::string, std::pair<double, bool>>::iterator m_s_d_iterator;
-    for (m_s_d_iterator = mass_stiffness_damping_map_.begin();
-         m_s_d_iterator != mass_stiffness_damping_map_.end(); ++m_s_d_iterator) {
-      // If parameter got changed, update configuration
-      if (m_s_d_iterator->second.second) {
-        m_s_d_iterator->second.first =
-          node->get_parameter(m_s_d_iterator->first).get_value<double>();
-        RCLCPP_INFO(node->get_logger(),
-          "Successfully updated param '%s', new value: '%f'",
-          m_s_d_iterator->first.c_str(), m_s_d_iterator->second.first);
-        m_s_d_iterator->second.second = false;
-      }
-    }
-    return true;
-  };
-  // Admittance parameters
-  // Arrays with dynamic paramter values
-  std::array<bool, 6> selected_axes_;
-  std::array<double, 6> mass_;
-  std::array<double, 6> damping_;
-  std::array<double, 6> damping_ratio_;
-  std::array<double, 6> stiffness_;
-
-  // Map of pairs <selected_axes, value_updated>
-  std::map<std::string, std::pair<bool, bool>> selected_axes_map_ = {
-    {"admittance.selected_axes.x", {selected_axes_[0], false}},
-    {"admittance.selected_axes.y", {selected_axes_[1], false}},
-    {"admittance.selected_axes.z", {selected_axes_[2], false}},
-    {"admittance.selected_axes.rx", {selected_axes_[3], false}},
-    {"admittance.selected_axes.ry", {selected_axes_[4], false}},
-    {"admittance.selected_axes.rz", {selected_axes_[5], false}}
-  };
-
-  // Map of pairs <mass/stiffness/damping, value_updated>
-  std::map<std::string, std::pair<double, bool>> mass_stiffness_damping_map_ = {
-    {"admittance.mass.x", {mass_[0], false}},
-    {"admittance.mass.y", {mass_[1], false}},
-    {"admittance.mass.z", {mass_[2], false}},
-    {"admittance.mass.rx", {mass_[3], false}},
-    {"admittance.mass.ry", {mass_[4], false}},
-    {"admittance.mass.rz", {mass_[5], false}},
-    {"admittance.damping.x", {damping_[0], false}},
-    {"admittance.damping.y", {damping_[1], false}},
-    {"admittance.damping.z", {damping_[2], false}},
-    {"admittance.damping.rx", {damping_[3], false}},
-    {"admittance.damping.ry", {damping_[4], false}},
-    {"admittance.damping.rz", {damping_[5], false}},
-    {"admittance.stiffness.x", {stiffness_[0], false}},
-    {"admittance.stiffness.y", {stiffness_[1], false}},
-    {"admittance.stiffness.z", {stiffness_[2], false}},
-    {"admittance.stiffness.rx", {stiffness_[3], false}},
-    {"admittance.stiffness.ry", {stiffness_[4], false}},
-    {"admittance.stiffness.rz", {stiffness_[5], false}},
-    {"admittance.damping_ratio.x", {damping_ratio_[0], false}},
-    {"admittance.damping_ratio.y", {damping_ratio_[1], false}},
-    {"admittance.damping_ratio.z", {damping_ratio_[2], false}},
-    {"admittance.damping_ratio.rx", {damping_ratio_[3], false}},
-    {"admittance.damping_ratio.ry", {damping_ratio_[4], false}},
-    {"admittance.damping_ratio.rz", {damping_ratio_[5], false}}
-  };
-};
 
 class AdmittanceRule
 {
@@ -395,9 +314,9 @@ public:
    */
   void convert_damping_ratio_to_damping() 
   {
-    for (auto i = 0ul; i < dynamic_param_.damping_ratio_.size(); ++i) {
-      if (!std::isnan(dynamic_param_.damping_ratio_[i])) {
-        dynamic_param_.damping_[i] = dynamic_param_.damping_ratio_[i] * 2 * sqrt(dynamic_param_.mass_[i] * dynamic_param_.stiffness_[i]);
+    for (auto i = 0ul; i < parameters_.damping_ratio_.size(); ++i) {
+      if (!std::isnan( parameters_.damping_ratio_[i])) {
+                parameters_.damping_[i] = parameters_.damping_ratio_[i] * 2 * sqrt( parameters_.mass_[i] * parameters_.stiffness_[i]);
       }
     }
   }
@@ -425,7 +344,7 @@ public:
   bool unified_mode_ = false;  // Unified mode enables simultaneous force and position goals
 
   // Dynamic admittance parameters
-  AdmittanceParameters dynamic_param_;
+  AdmittanceParameters parameters_;
 
   // Filter chain for Wrench data
   std::unique_ptr<filters::FilterChain<geometry_msgs::msg::WrenchStamped>> filter_chain_;

--- a/admittance_controller/include/admittance_controller/admittance_rule.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule.hpp
@@ -17,6 +17,8 @@
 #ifndef ADMITTANCE_CONTROLLER__ADMITTANCE_RULE_HPP_
 #define ADMITTANCE_CONTROLLER__ADMITTANCE_RULE_HPP_
 
+#include "angles/angles.h"
+
 #include "admittance_controller/moveit_kinematics.hpp"
 #include "control_msgs/msg/admittance_controller_state.hpp"
 #include "controller_interface/controller_interface.hpp"
@@ -27,6 +29,139 @@
 #include "geometry_msgs/msg/wrench_stamped.hpp"
 #include "tf2_ros/transform_listener.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+
+namespace {  // Utility namespace
+
+// Numerical accuracy checks. Used as deadbands.
+static constexpr double WRENCH_EPSILON = 1e-10;
+static constexpr double POSE_ERROR_EPSILON = 1e-12;
+static constexpr double POSE_EPSILON = 1e-15;
+
+template<typename Type>
+void convert_message_to_array(const geometry_msgs::msg::Pose & msg, Type & vector_out)
+{
+  vector_out[0] = msg.position.x;
+  vector_out[1] = msg.position.y;
+  vector_out[2] = msg.position.z;
+  tf2::Quaternion q;
+  tf2::fromMsg(msg.orientation, q);
+  q.normalize();
+  tf2::Matrix3x3(q).getRPY(vector_out[3], vector_out[4], vector_out[5]);
+  for (auto i = 3u; i < 6; ++i) {
+    vector_out[i] = angles::normalize_angle(vector_out[i]);
+  }
+}
+
+template<typename Type>
+void convert_message_to_array(
+  const geometry_msgs::msg::PoseStamped & msg, Type & vector_out)
+{
+  convert_message_to_array(msg.pose, vector_out);
+}
+
+template<typename Type>
+void convert_message_to_array(const geometry_msgs::msg::Transform & msg, Type & vector_out)
+{
+  vector_out[0] = msg.translation.x;
+  vector_out[1] = msg.translation.y;
+  vector_out[2] = msg.translation.z;
+  tf2::Quaternion q;
+  tf2::fromMsg(msg.rotation, q);
+  q.normalize();
+  tf2::Matrix3x3(q).getRPY(vector_out[3], vector_out[4], vector_out[5]);
+  for (auto i = 3u; i < 6; ++i) {
+    vector_out[i] = angles::normalize_angle(vector_out[i]);
+  }
+}
+
+template<typename Type>
+void convert_message_to_array(const geometry_msgs::msg::TransformStamped & msg, Type & vector_out)
+{
+  convert_message_to_array(msg.transform, vector_out);
+}
+
+template<typename Type>
+void convert_message_to_array(
+  const geometry_msgs::msg::Wrench & msg, Type & vector_out)
+{
+  vector_out[0] = msg.force.x;
+  vector_out[1] = msg.force.y;
+  vector_out[2] = msg.force.z;
+  vector_out[3] = msg.torque.x;
+  vector_out[4] = msg.torque.y;
+  vector_out[5] = msg.torque.z;
+}
+
+template<typename Type>
+void convert_message_to_array(
+  const geometry_msgs::msg::WrenchStamped & msg, Type & vector_out)
+{
+  convert_message_to_array(msg.wrench, vector_out);
+}
+
+template<typename Type>
+void convert_array_to_message(const Type & vector, geometry_msgs::msg::Pose & msg_out)
+{
+  msg_out.position.x = vector[0];
+  msg_out.position.y = vector[1];
+  msg_out.position.z = vector[2];
+
+  tf2::Quaternion q;
+  q.setRPY(vector[3], vector[4], vector[5]);
+
+  msg_out.orientation.x = q.x();
+  msg_out.orientation.y = q.y();
+  msg_out.orientation.z = q.z();
+  msg_out.orientation.w = q.w();
+}
+
+template<typename Type>
+void convert_array_to_message(const Type & vector, geometry_msgs::msg::PoseStamped & msg_out)
+{
+  convert_array_to_message(vector, msg_out.pose);
+}
+
+// template<typename Type>
+// void convert_array_to_message(const Type & vector, geometry_msgs::msg::Wrench & msg_out)
+// {
+//   msg_out.force.x = vector[0];
+//   msg_out.force.y = vector[1];
+//   msg_out.force.z = vector[2];
+//   msg_out.torque.x = vector[3];
+//   msg_out.torque.y = vector[4];
+//   msg_out.torque.z = vector[5];
+// }
+
+// template<typename Type>
+// void convert_array_to_message(const Type & vector, geometry_msgs::msg::WrenchStamped & msg_out)
+// {
+//   convert_array_to_message(vector, msg_out.wrench);
+// }
+
+template<typename Type>
+void convert_array_to_message(const Type & vector, geometry_msgs::msg::Transform & msg_out)
+{
+  msg_out.translation.x = vector[0];
+  msg_out.translation.y = vector[1];
+  msg_out.translation.z = vector[2];
+
+  tf2::Quaternion q;
+  q.setRPY(vector[3], vector[4], vector[5]);
+
+  msg_out.rotation.x = q.x();
+  msg_out.rotation.y = q.y();
+  msg_out.rotation.z = q.z();
+  msg_out.rotation.w = q.w();
+}
+
+template<typename Type>
+void convert_array_to_message(const Type & vector, geometry_msgs::msg::TransformStamped & msg_out)
+{
+  convert_array_to_message(vector, msg_out.transform);
+}
+
+}  // utility namespace
+
 
 namespace admittance_controller
 {
@@ -97,17 +232,12 @@ public:
   bool feedforward_commanded_input_ = true;
 
   // IK related parameters
-  // ik_base_frame should be stationary so vel/accel calculations are correct
   std::string ik_base_frame_;
-  std::string ik_tip_frame_;
   std::string ik_group_name_;
 
-  // Frame which position should be controlled
-  std::string endeffector_frame_;
-  // Admittance calcs (displacement etc) are done in this frame. Usually the tool or end-effector
+  // Admittance calculations (displacement etc) are done in this frame.
+  // Depends on the scenario: usually base_link, tool or end-effector
   std::string control_frame_;
-  // Gravity points down (neg. Z) in the world frame
-  std::string fixed_world_frame_;
   // Frame where wrench measurements are taken
   std::string sensor_frame_;
 
@@ -143,6 +273,7 @@ protected:
 
   controller_interface::return_type calculate_desired_joint_state(
     const trajectory_msgs::msg::JointTrajectoryPoint & current_joint_state,
+    const std::array<double, 6> & relative_pose,
     const rclcpp::Duration & period,
     trajectory_msgs::msg::JointTrajectoryPoint & desired_joint_state
   );
@@ -157,17 +288,14 @@ protected:
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
-  tf2::Transform ik_tip_to_control_frame_tf_;
-  tf2::Transform control_frame_to_ik_tip_tf_;
-
   // measured_wrench_ could arrive in any frame. It will be transformed
   geometry_msgs::msg::WrenchStamped measured_wrench_;
   geometry_msgs::msg::WrenchStamped measured_wrench_filtered_;
 
   geometry_msgs::msg::WrenchStamped measured_wrench_ik_base_frame_;
-  geometry_msgs::msg::WrenchStamped measured_wrench_endeffector_frame_;
 
   geometry_msgs::msg::PoseStamped current_pose_ik_base_frame_;
+  geometry_msgs::msg::PoseStamped current_pose_control_frame_;
 
   // This is the feedforward pose. Where should the end effector be with no wrench applied?
   geometry_msgs::msg::PoseStamped reference_pose_from_joint_deltas_ik_base_frame_;
@@ -177,9 +305,15 @@ protected:
 
   geometry_msgs::msg::WrenchStamped reference_force_ik_base_frame_;
   geometry_msgs::msg::PoseStamped reference_pose_ik_base_frame_;
+  geometry_msgs::msg::PoseStamped reference_pose_control_frame_;
 
   geometry_msgs::msg::PoseStamped admittance_pose_ik_base_frame_;
-  geometry_msgs::msg::TransformStamped relative_admittance_pose_;
+  geometry_msgs::msg::PoseStamped sum_of_admittance_displacements_;
+  geometry_msgs::msg::PoseStamped sum_of_admittance_displacements_control_frame_;
+  geometry_msgs::msg::TransformStamped relative_admittance_pose_ik_base_frame_;
+  geometry_msgs::msg::TransformStamped relative_admittance_pose_control_frame_;
+  geometry_msgs::msg::TransformStamped admittance_velocity_ik_base_frame_;
+  geometry_msgs::msg::TransformStamped admittance_velocity_control_frame_;
 
   // Joint deltas calculation variables
   std::vector<double> reference_joint_deltas_vec_;
@@ -190,14 +324,14 @@ protected:
 
   // Pre-reserved update-loop variables
   std::array<double, 6> measured_wrench_ik_base_frame_arr_;
-  std::array<double, 6> reference_pose_ik_base_frame_arr_;
-  std::array<double, 6> current_pose_ik_base_frame_arr_;
+  std::array<double, 6> reference_pose_arr_;
+  std::array<double, 6> current_pose_arr_;
 
   std::array<double, 6> relative_admittance_pose_arr_;
   std::array<double, 6> admittance_pose_ik_base_frame_arr_;
   std::array<double, 6> admittance_velocity_arr_;
   // Keep a running tally of motion due to admittance, to calculate spring force in open-loop mode
-  std::array<double, 6> sum_of_admittance_displacements_;
+  std::array<double, 6> sum_of_admittance_displacements_arr_;
 
   std::vector<double> relative_desired_joint_state_vec_;
 
@@ -210,12 +344,26 @@ protected:
 private:
   template<typename MsgType>
   controller_interface::return_type
-  transform_message_to_ik_base_frame(const MsgType & message_in, MsgType & message_out)
+  transform_to_control_frame(const MsgType & message_in, MsgType & message_out)
   {
-    if (ik_base_frame_ != message_in.header.frame_id) {
+    return transform_to_frame(message_in, message_out, control_frame_);
+  }
+
+  template<typename MsgType>
+  controller_interface::return_type
+  transform_to_ik_base_frame(const MsgType & message_in, MsgType & message_out)
+  {
+    return transform_to_frame(message_in, message_out, ik_base_frame_);
+  }
+
+  template<typename MsgType>
+  controller_interface::return_type
+  transform_to_frame(const MsgType & message_in, MsgType & message_out, const std::string & frame)
+  {
+    if (frame != message_in.header.frame_id) {
       try {
         geometry_msgs::msg::TransformStamped transform = tf_buffer_->lookupTransform(
-          ik_base_frame_, message_in.header.frame_id, tf2::TimePointZero);
+          frame, message_in.header.frame_id, tf2::TimePointZero);
         tf2::doTransform(message_in, message_out, transform);
       } catch (const tf2::TransformException & e) {
         RCLCPP_ERROR_SKIPFIRST_THROTTLE(
@@ -228,6 +376,73 @@ private:
     return controller_interface::return_type::OK;
   }
 
+  template<typename MsgType>
+  controller_interface::return_type
+  transform_relative_to_control_frame(const MsgType & message_in, MsgType & message_out)
+  {
+    return transform_relative_to_frame(message_in, message_out, control_frame_);
+  }
+
+  template<typename MsgType>
+  controller_interface::return_type
+  transform_relative_to_ik_base_frame(const MsgType & message_in, MsgType & message_out)
+  {
+    return transform_relative_to_frame(message_in, message_out, ik_base_frame_);
+  }
+
+  /**
+   * Transforms relative movement/pose to a new frame.
+   * Consider following discussion/approaches in the future the:
+   *   - https://answers.ros.org/question/192273/how-to-implement-velocity-transformation/?answer=192283#post-id-192283
+   *   - https://physics.stackexchange.com/questions/197009/transform-velocities-from-one-frame-to-an-other-within-a-rigid-body#244364
+   */
+  template<typename MsgType>
+  controller_interface::return_type
+  transform_relative_to_frame(const MsgType & message_in, MsgType & message_out, const std::string & frame)
+  {
+    controller_interface::return_type ret = controller_interface::return_type::OK;
+
+    // Do calculation only if transformation needed
+    if (frame != message_in.header.frame_id) {
+
+      MsgType message_transformed;
+      std::array<double, 6> message_transformed_arr;
+
+      geometry_msgs::msg::PoseStamped zero_pose;
+      geometry_msgs::msg::PoseStamped zero_pose_transformed;
+      std::array<double, 6> zero_pose_transformed_arr;
+
+      std::array<double, 6> relative_message_transformed_arr;
+
+      ret = transform_to_frame(message_in, message_transformed, frame);
+      convert_message_to_array(message_transformed, message_transformed_arr);
+
+      zero_pose.header.frame_id = message_in.header.frame_id;
+      ret = transform_to_frame(zero_pose, zero_pose_transformed, frame);
+      convert_message_to_array(zero_pose_transformed, zero_pose_transformed_arr);
+
+      for (auto i = 0u; i < 6; ++i) {
+        relative_message_transformed_arr[i] =
+          message_transformed_arr[i] - zero_pose_transformed_arr[i];
+
+        if (i >= 3) {
+          relative_message_transformed_arr[i] =
+            angles::normalize_angle(relative_message_transformed_arr[i]);
+        }
+
+        if (std::fabs(relative_message_transformed_arr[i]) < POSE_ERROR_EPSILON) {
+          relative_message_transformed_arr[i] = 0.0;
+        }
+      }
+      message_out.header = message_transformed.header;
+      convert_array_to_message(relative_message_transformed_arr, message_out);
+    } else {
+      message_out = message_in;
+    }
+
+    return ret;
+  }
+
   template<typename Type>
   void
   direct_transform(const Type & input, const tf2::Transform & transform, Type & output)
@@ -238,17 +453,6 @@ private:
     tf2::fromMsg(input, input_tf);
     output_tf = input_tf * transform;
     tf2::toMsg(output_tf, output);
-  }
-
-  // TODO(destogl): As of C++17 use transform_reduce:
-  // https://stackoverflow.com/questions/58266717/accumulate-absolute-values-of-a-vector
-  template<typename Type>
-  double accumulate_absolute(const Type & container) {
-    double accumulator = 0.0;
-    for (auto i = 0ul; i < container.size(); i++) {
-      accumulator += std::fabs(container[i]);
-    }
-    return accumulator;
   }
 };
 

--- a/admittance_controller/include/admittance_controller/admittance_rule.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule.hpp
@@ -212,7 +212,7 @@ public:
     int index = 0;
     // check if parameters are all properly set for selected axes
     for (auto i = 0ul; i < bool_parameters_.size(); ++i) {
-      if (bool_parameters_[index].second) {
+      if (bool_parameters_[i].second) {
         // check mass parameters
         index = i;
         if (std::isnan(double_parameters_[index].second)) {
@@ -252,7 +252,7 @@ public:
   {
     for (auto i = 0ul; i < 6; ++i) {
       selected_axes_[i] = bool_parameters_[i].second;
-      
+
       mass_[i] = double_parameters_[i].second;
       stiffness_[i] = double_parameters_[i+6].second;
       damping_[i] = double_parameters_[i+12].second;

--- a/admittance_controller/include/admittance_controller/admittance_rule.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule.hpp
@@ -31,6 +31,7 @@
 #include "geometry_msgs/msg/wrench_stamped.hpp"
 #include "tf2_ros/transform_listener.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "rcutils/logging_macros.h"
 
 namespace {  // Utility namespace
 
@@ -205,7 +206,7 @@ public:
     add_double_parameter("admittance.damping_ratio.rz", true);
   }
   
-  bool check_if_parameters_are_valid(rclcpp::Node::SharedPtr node) override
+  bool check_if_parameters_are_valid() override
   {
     bool ret = true;
     int index = 0;
@@ -215,17 +216,17 @@ public:
         // check mass parameters
         index = i;
         if (std::isnan(double_parameters_[index].second)) {
-          RCLCPP_ERROR(node->get_logger(), 
-                       "Parameter '%s' has to be set", 
-                       double_parameters_[index].first.name.c_str());
+          RCUTILS_LOG_ERROR_NAMED(
+            logger_name_.c_str(),
+            "Parameter '%s' has to be set", double_parameters_[index].first.name.c_str());
           ret = false;
         }
         // Check stiffness parameters
         index = i + 6;
         if (std::isnan(double_parameters_[index].second)) {
-          RCLCPP_ERROR(node->get_logger(), 
-                       "Parameter '%s' has to be set", 
-                       double_parameters_[index].first.name.c_str());
+          RCUTILS_LOG_ERROR_NAMED(
+            logger_name_.c_str(),
+            "Parameter '%s' has to be set", double_parameters_[index].first.name.c_str());
           ret = false;
         }
         // Check damping or damping_ratio parameters
@@ -233,11 +234,12 @@ public:
         if (std::isnan(double_parameters_[index].second) && 
             std::isnan(double_parameters_[index + 6].second)
         ) {
-          RCLCPP_ERROR(node->get_logger(), 
-                       "Either parameter '%s' of '%s' has to be set", 
-                       double_parameters_[index].first.name.c_str(),
-                       double_parameters_[index + 6].first.name.c_str()
-                      );
+          RCUTILS_LOG_ERROR_NAMED(
+            logger_name_.c_str(),
+            "Either parameter '%s' of '%s' has to be set", 
+            double_parameters_[index].first.name.c_str(),
+            double_parameters_[index + 6].first.name.c_str()
+          );
           ret = false;
         }
       }

--- a/admittance_controller/include/admittance_controller/admittance_rule.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule.hpp
@@ -17,8 +17,9 @@
 #ifndef ADMITTANCE_CONTROLLER__ADMITTANCE_RULE_HPP_
 #define ADMITTANCE_CONTROLLER__ADMITTANCE_RULE_HPP_
 
-#include "angles/angles.h"
+#include <map>
 
+#include "angles/angles.h"
 #include "admittance_controller/moveit_kinematics.hpp"
 #include "control_msgs/msg/admittance_controller_state.hpp"
 #include "controller_interface/controller_interface.hpp"
@@ -174,6 +175,88 @@ public:
   double force_;
 };
 
+struct DynamicAdmittanceParameters
+{
+public:
+  // Reconfigure updated parameters
+  bool update(std::shared_ptr<rclcpp::Node> node)
+  {
+    // Check for updated selected_axes_
+    std::map<std::string, std::pair<bool, bool>>::iterator axes_iterator;
+    for (axes_iterator = selected_axes_map_.begin(); axes_iterator != selected_axes_map_.end();
+         ++axes_iterator) {
+      // If parameter got changed, update configuration
+      if (axes_iterator->second.second) {
+        axes_iterator->second.first = node->get_parameter(axes_iterator->first).get_value<bool>();
+        RCLCPP_INFO(node->get_logger(),
+          "Successfully updated param '%s', new value: '%d'", axes_iterator->first.c_str(), axes_iterator->second.first);
+
+        axes_iterator->second.second = false;
+      }
+    }
+    // Check for updated mass, stiffness, damping or damping_ratio values
+    std::map<std::string, std::pair<double, bool>>::iterator m_s_d_iterator;
+    for (m_s_d_iterator = mass_stiffness_damping_map_.begin();
+         m_s_d_iterator != mass_stiffness_damping_map_.end(); ++m_s_d_iterator) {
+      // If parameter got changed, update configuration
+      if (m_s_d_iterator->second.second) {
+        m_s_d_iterator->second.first =
+          node->get_parameter(m_s_d_iterator->first).get_value<double>();
+        RCLCPP_INFO(node->get_logger(),
+          "Successfully updated param '%s', new value: '%f'",
+          m_s_d_iterator->first.c_str(), m_s_d_iterator->second.first);
+        m_s_d_iterator->second.second = false;
+      }
+    }
+    return true;
+  };
+  // Admittance parameters
+  // Arrays with dynamic paramter values
+  std::array<bool, 6> selected_axes_;
+  std::array<double, 6> mass_;
+  std::array<double, 6> damping_;
+  std::array<double, 6> damping_ratio_;
+  std::array<double, 6> stiffness_;
+
+  // Map of pairs <selected_axes, value_updated>
+  std::map<std::string, std::pair<bool, bool>> selected_axes_map_ = {
+    {"admittance.selected_axes.x", {selected_axes_[0], false}},
+    {"admittance.selected_axes.y", {selected_axes_[1], false}},
+    {"admittance.selected_axes.z", {selected_axes_[2], false}},
+    {"admittance.selected_axes.rx", {selected_axes_[3], false}},
+    {"admittance.selected_axes.ry", {selected_axes_[4], false}},
+    {"admittance.selected_axes.rz", {selected_axes_[5], false}}
+  };
+
+  // Map of pairs <mass/stiffness/damping, value_updated>
+  std::map<std::string, std::pair<double, bool>> mass_stiffness_damping_map_ = {
+    {"admittance.mass.x", {mass_[0], false}},
+    {"admittance.mass.y", {mass_[1], false}},
+    {"admittance.mass.z", {mass_[2], false}},
+    {"admittance.mass.rx", {mass_[3], false}},
+    {"admittance.mass.ry", {mass_[4], false}},
+    {"admittance.mass.rz", {mass_[5], false}},
+    {"admittance.damping.x", {damping_[0], false}},
+    {"admittance.damping.y", {damping_[1], false}},
+    {"admittance.damping.z", {damping_[2], false}},
+    {"admittance.damping.rx", {damping_[3], false}},
+    {"admittance.damping.ry", {damping_[4], false}},
+    {"admittance.damping.rz", {damping_[5], false}},
+    {"admittance.stiffness.x", {stiffness_[0], false}},
+    {"admittance.stiffness.y", {stiffness_[1], false}},
+    {"admittance.stiffness.z", {stiffness_[2], false}},
+    {"admittance.stiffness.rx", {stiffness_[3], false}},
+    {"admittance.stiffness.ry", {stiffness_[4], false}},
+    {"admittance.stiffness.rz", {stiffness_[5], false}},
+    {"admittance.damping_ratio.x", {damping_ratio_[0], false}},
+    {"admittance.damping_ratio.y", {damping_ratio_[1], false}},
+    {"admittance.damping_ratio.z", {damping_ratio_[2], false}},
+    {"admittance.damping_ratio.rx", {damping_ratio_[3], false}},
+    {"admittance.damping_ratio.ry", {damping_ratio_[4], false}},
+    {"admittance.damping_ratio.rz", {damping_ratio_[5], false}}
+  };
+};
+
 class AdmittanceRule
 {
 public:
@@ -219,9 +302,9 @@ public:
    * Using formula: D = damping_ratio * 2 * sqrt( M * S )
    */
   void convert_damping_ratio_to_damping() {
-    for (auto i = 0ul; i < damping_ratio_.size(); ++i) {
-      if (!std::isnan(damping_ratio_[i])) {
-        damping_[i] = damping_ratio_[i] * 2 * sqrt(mass_[i] * stiffness_[i]);
+    for (auto i = 0ul; i < dynamic_param_.damping_ratio_.size(); ++i) {
+      if (!std::isnan(dynamic_param_.damping_ratio_[i])) {
+        dynamic_param_.damping_[i] = dynamic_param_.damping_ratio_[i] * 2 * sqrt(dynamic_param_.mass_[i] * dynamic_param_.stiffness_[i]);
       }
     }
   }
@@ -247,11 +330,9 @@ public:
   // Admittance parameters
   // TODO(destogl): unified mode does not have to be here
   bool unified_mode_ = false;  // Unified mode enables simultaneous force and position goals
-  std::array<bool, 6> selected_axes_;
-  std::array<double, 6> mass_;
-  std::array<double, 6> damping_;
-  std::array<double, 6> damping_ratio_;
-  std::array<double, 6> stiffness_;
+
+  // Dynamic admittance parameters
+  DynamicAdmittanceParameters dynamic_param_;
 
   // Filter chain for Wrench data
   std::unique_ptr<filters::FilterChain<geometry_msgs::msg::WrenchStamped>> filter_chain_;

--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -28,138 +28,6 @@
 #include "tf2/utils.h"
 #include "tf2_eigen/tf2_eigen.h"
 
-namespace {  // Utility namespace
-
-// Numerical accuracy checks. Used as deadbands.
-static constexpr double WRENCH_EPSILON = 1e-10;
-static constexpr double POSE_ERROR_EPSILON = 1e-12;
-static constexpr double POSE_EPSILON = 1e-15;
-
-template<typename Type>
-void convert_message_to_array(const geometry_msgs::msg::Pose & msg, Type & vector_out)
-{
-  vector_out[0] = msg.position.x;
-  vector_out[1] = msg.position.y;
-  vector_out[2] = msg.position.z;
-  tf2::Quaternion q;
-  tf2::fromMsg(msg.orientation, q);
-  q.normalize();
-  tf2::Matrix3x3(q).getRPY(vector_out[3], vector_out[4], vector_out[5]);
-  for (auto i = 3u; i < 6; ++i) {
-    vector_out[i] = angles::normalize_angle(vector_out[i]);
-  }
-}
-
-template<typename Type>
-void convert_message_to_array(
-  const geometry_msgs::msg::PoseStamped & msg, Type & vector_out)
-{
-  convert_message_to_array(msg.pose, vector_out);
-}
-
-template<typename Type>
-void convert_message_to_array(const geometry_msgs::msg::Transform & msg, Type & vector_out)
-{
-  vector_out[0] = msg.translation.x;
-  vector_out[1] = msg.translation.y;
-  vector_out[2] = msg.translation.z;
-  tf2::Quaternion q;
-  tf2::fromMsg(msg.rotation, q);
-  q.normalize();
-  tf2::Matrix3x3(q).getRPY(vector_out[3], vector_out[4], vector_out[5]);
-  for (auto i = 3u; i < 6; ++i) {
-    vector_out[i] = angles::normalize_angle(vector_out[i]);
-  }
-}
-
-template<typename Type>
-void convert_message_to_array(const geometry_msgs::msg::TransformStamped & msg, Type & vector_out)
-{
-  convert_message_to_array(msg.transform, vector_out);
-}
-
-template<typename Type>
-void convert_message_to_array(
-  const geometry_msgs::msg::Wrench & msg, Type & vector_out)
-{
-  vector_out[0] = msg.force.x;
-  vector_out[1] = msg.force.y;
-  vector_out[2] = msg.force.z;
-  vector_out[3] = msg.torque.x;
-  vector_out[4] = msg.torque.y;
-  vector_out[5] = msg.torque.z;
-}
-
-template<typename Type>
-void convert_message_to_array(
-  const geometry_msgs::msg::WrenchStamped & msg, Type & vector_out)
-{
-  convert_message_to_array(msg.wrench, vector_out);
-}
-
-template<typename Type>
-void convert_array_to_message(const Type & vector, geometry_msgs::msg::Pose & msg_out)
-{
-  msg_out.position.x = vector[0];
-  msg_out.position.y = vector[1];
-  msg_out.position.z = vector[2];
-
-  tf2::Quaternion q;
-  q.setRPY(vector[3], vector[4], vector[5]);
-
-  msg_out.orientation.x = q.x();
-  msg_out.orientation.y = q.y();
-  msg_out.orientation.z = q.z();
-  msg_out.orientation.w = q.w();
-}
-
-template<typename Type>
-void convert_array_to_message(const Type & vector, geometry_msgs::msg::PoseStamped & msg_out)
-{
-  convert_array_to_message(vector, msg_out.pose);
-}
-
-// template<typename Type>
-// void convert_array_to_message(const Type & vector, geometry_msgs::msg::Wrench & msg_out)
-// {
-//   msg_out.force.x = vector[0];
-//   msg_out.force.y = vector[1];
-//   msg_out.force.z = vector[2];
-//   msg_out.torque.x = vector[3];
-//   msg_out.torque.y = vector[4];
-//   msg_out.torque.z = vector[5];
-// }
-
-// template<typename Type>
-// void convert_array_to_message(const Type & vector, geometry_msgs::msg::WrenchStamped & msg_out)
-// {
-//   convert_array_to_message(vector, msg_out.wrench);
-// }
-
-template<typename Type>
-void convert_array_to_message(const Type & vector, geometry_msgs::msg::Transform & msg_out)
-{
-  msg_out.translation.x = vector[0];
-  msg_out.translation.y = vector[1];
-  msg_out.translation.z = vector[2];
-
-  tf2::Quaternion q;
-  q.setRPY(vector[3], vector[4], vector[5]);
-
-  msg_out.rotation.x = q.x();
-  msg_out.rotation.y = q.y();
-  msg_out.rotation.z = q.z();
-  msg_out.rotation.w = q.w();
-}
-
-template<typename Type>
-void convert_array_to_message(const Type & vector, geometry_msgs::msg::TransformStamped & msg_out)
-{
-  convert_array_to_message(vector, msg_out.transform);
-}
-
-}  // utility namespace
-
 namespace admittance_controller
 {
 
@@ -172,11 +40,23 @@ controller_interface::return_type AdmittanceRule::configure(rclcpp::Node::Shared
   // Initialize variables used in the update loop
   measured_wrench_.header.frame_id = sensor_frame_;
 
-  relative_admittance_pose_.header.frame_id = control_frame_;
-  relative_admittance_pose_.child_frame_id = control_frame_;
+  // The variables represent transformation within the same frame
+  relative_admittance_pose_ik_base_frame_.header.frame_id = ik_base_frame_;
+  relative_admittance_pose_ik_base_frame_.child_frame_id = ik_base_frame_;
+  relative_admittance_pose_control_frame_.header.frame_id = control_frame_;
+  relative_admittance_pose_control_frame_.child_frame_id = control_frame_;
+
+  // The variables represent transformation within the same frame
+  admittance_velocity_ik_base_frame_.header.frame_id = ik_base_frame_;
+  admittance_velocity_ik_base_frame_.child_frame_id = ik_base_frame_;
+  admittance_velocity_control_frame_.header.frame_id = control_frame_;
+  admittance_velocity_control_frame_.child_frame_id = control_frame_;
+
+  sum_of_admittance_displacements_.header.frame_id = ik_base_frame_;
 
   reference_joint_deltas_vec_.reserve(6);
   reference_deltas_vec_ik_base_.reserve(6);
+  // The variables represent transformation within the same frame
   reference_deltas_ik_base_.header.frame_id = ik_base_frame_;
   reference_deltas_ik_base_.child_frame_id = ik_base_frame_;
 
@@ -198,10 +78,10 @@ controller_interface::return_type AdmittanceRule::configure(rclcpp::Node::Shared
 controller_interface::return_type AdmittanceRule::reset()
 {
   measured_wrench_ik_base_frame_arr_.fill(0.0);
-  reference_pose_ik_base_frame_arr_.fill(0.0);
-  current_pose_ik_base_frame_arr_.fill(0.0);
+  reference_pose_arr_.fill(0.0);
+  current_pose_arr_.fill(0.0);
   admittance_velocity_arr_.fill(0.0);
-  sum_of_admittance_displacements_.fill(0.0);
+  sum_of_admittance_displacements_arr_.fill(0.0);
 
   get_pose_of_control_frame_in_base_frame(current_pose_ik_base_frame_);
   reference_pose_from_joint_deltas_ik_base_frame_ = current_pose_ik_base_frame_;
@@ -211,19 +91,6 @@ controller_interface::return_type AdmittanceRule::reset()
   if (open_loop_control_) {
     get_pose_of_control_frame_in_base_frame(admittance_pose_ik_base_frame_);
     convert_message_to_array(admittance_pose_ik_base_frame_, admittance_pose_ik_base_frame_arr_);
-  }
-
-  // Initialize ik_tip and tool_frame transformations - those are fixed transformations
-  tf2::Stamped<tf2::Transform> tf2_transform;
-  try {
-    auto transform = tf_buffer_->lookupTransform(ik_tip_frame_, control_frame_, tf2::TimePointZero);
-    tf2::fromMsg(transform, tf2_transform);
-    ik_tip_to_control_frame_tf_ = tf2_transform;
-    control_frame_to_ik_tip_tf_ = tf2_transform.inverse();
-  } catch (const tf2::TransformException & e) {
-    RCLCPP_ERROR_SKIPFIRST_THROTTLE(
-      rclcpp::get_logger("AdmittanceRule"), *clock_, 5000, "%s", e.what());
-    return controller_interface::return_type::ERROR;
   }
 
   return controller_interface::return_type::OK;
@@ -239,54 +106,77 @@ controller_interface::return_type AdmittanceRule::update(
 )
 {
   // Convert inputs to ik_base frame (assumed stationary)
-  transform_message_to_ik_base_frame(reference_pose, reference_pose_ik_base_frame_);
+  transform_to_ik_base_frame(reference_pose, reference_pose_ik_base_frame_);
+
+  std::array<double, 6> pose_error;
+  geometry_msgs::msg::TransformStamped pose_error_pose;
+  pose_error_pose.header.frame_id = ik_base_frame_;
+  pose_error_pose.child_frame_id = control_frame_;
 
   if (!open_loop_control_) {
     get_pose_of_control_frame_in_base_frame(current_pose_ik_base_frame_);
+
+    // Convert all data to arrays for simpler calculation
+    transform_to_control_frame(reference_pose_ik_base_frame_, current_pose_control_frame_);
+    convert_message_to_array(current_pose_control_frame_, reference_pose_arr_);
+    transform_to_control_frame(current_pose_ik_base_frame_, reference_pose_control_frame_);
+    convert_message_to_array(reference_pose_control_frame_, current_pose_arr_);
+
+    for (auto i = 0u; i < 6; ++i) {
+      pose_error[i] = current_pose_arr_[i] - reference_pose_arr_[i];
+
+      if (i >= 3) {
+        pose_error[i] = angles::normalize_angle(pose_error[i]);
+      }
+      if (std::fabs(pose_error[i]) < POSE_ERROR_EPSILON) {
+        pose_error[i] = 0.0;
+      }
+    }
+
   } else {
     // In open-loop mode, assume the user's requested pose was exactly achieved
     // TODO(destogl): This will maybe now work when no feed-forward is used
     current_pose_ik_base_frame_ = reference_pose_ik_base_frame_;
-  }
 
-  // Convert all data to arrays for simpler calculation
-  convert_message_to_array(reference_pose_ik_base_frame_, reference_pose_ik_base_frame_arr_);
-  convert_message_to_array(current_pose_ik_base_frame_, current_pose_ik_base_frame_arr_);
-
-  std::array<double, 6> pose_error;
-
-  for (auto i = 0u; i < 6; ++i) {
-
-    if (!open_loop_control_) {
-      pose_error[i] = current_pose_ik_base_frame_arr_[i] - reference_pose_ik_base_frame_arr_[i];
-    } else {
-      // Sum admittance displacement from the previous relative poses
-      sum_of_admittance_displacements_[i] += relative_admittance_pose_arr_[i];
-      // In open-loop mode, spring force is related to the accumulated "admittance displacement"
-      pose_error[i] = sum_of_admittance_displacements_[i];
+    // Sum admittance displacements (in ik_base_frame) from the previous relative poses
+    for (auto i = 0u; i < 6; ++i) {
+      sum_of_admittance_displacements_arr_[i] += relative_admittance_pose_arr_[i];
     }
 
-    if (i >= 3) {
-      pose_error[i] = angles::normalize_angle(pose_error[i]);
-    }
-    if (std::fabs(pose_error[i]) < POSE_ERROR_EPSILON) {
-      pose_error[i] = 0.0;
-    }
+    // Transform sum of admittance displacements to control frame
+    convert_array_to_message(sum_of_admittance_displacements_arr_, sum_of_admittance_displacements_);
+    transform_relative_to_control_frame(sum_of_admittance_displacements_, sum_of_admittance_displacements_control_frame_);
+    convert_message_to_array(sum_of_admittance_displacements_control_frame_, pose_error);
   }
 
   process_wrench_measurements(measured_wrench);
 
+  // Transform internal state to updated control frame - could be changed since the last update
+  transform_relative_to_control_frame(
+    admittance_velocity_ik_base_frame_, admittance_velocity_control_frame_);
+  convert_message_to_array(admittance_velocity_control_frame_, admittance_velocity_arr_);
+
+  // Calculate admittance rule in the control frame
   calculate_admittance_rule(
     measured_wrench_ik_base_frame_arr_, pose_error, period, relative_admittance_pose_arr_);
 
-  // This works in all cases because not current TF data are used
+  // Transform internal states from current "control" frame to "ik base" frame
   // Do clean conversion to the goal pose using transform and not messing with Euler angles
-  convert_array_to_message(relative_admittance_pose_arr_, relative_admittance_pose_);
+  convert_array_to_message(relative_admittance_pose_arr_, relative_admittance_pose_control_frame_);
+  transform_relative_to_ik_base_frame(
+    relative_admittance_pose_control_frame_, relative_admittance_pose_ik_base_frame_);
+  convert_message_to_array(relative_admittance_pose_ik_base_frame_, relative_admittance_pose_arr_);
+
+  convert_array_to_message(admittance_velocity_arr_, admittance_velocity_control_frame_);
+  transform_relative_to_ik_base_frame(
+    admittance_velocity_control_frame_, admittance_velocity_ik_base_frame_);
 
   // Add deltas to previously-desired pose to get the next desired pose
-  tf2::doTransform(current_pose_ik_base_frame_, admittance_pose_ik_base_frame_, relative_admittance_pose_);
+  tf2::doTransform(current_pose_ik_base_frame_, admittance_pose_ik_base_frame_,
+                   relative_admittance_pose_ik_base_frame_);
 
-  return calculate_desired_joint_state(current_joint_state, period, desired_joint_state);
+  return calculate_desired_joint_state(current_joint_state, relative_admittance_pose_arr_,
+                                       period, desired_joint_state);
 }
 
 // Update from target joint deltas
@@ -357,21 +247,11 @@ controller_interface::return_type AdmittanceRule::get_controller_state(
   state_message.measured_wrench_filtered = measured_wrench_filtered_;
   state_message.measured_wrench_control_frame = measured_wrench_ik_base_frame_;
 
-  // FIXME(destogl): Something is wrong with this transformation - check frames...
-  try {
-    auto transform = tf_buffer_->lookupTransform(endeffector_frame_, control_frame_, tf2::TimePointZero);
-    tf2::doTransform(measured_wrench_ik_base_frame_, measured_wrench_endeffector_frame_, transform);
-  } catch (const tf2::TransformException & e) {
-    RCLCPP_ERROR_SKIPFIRST_THROTTLE(
-      rclcpp::get_logger("AdmittanceRule"), *clock_, 5000, "%s", e.what());
-  }
-  state_message.measured_wrench_endeffector_frame = measured_wrench_endeffector_frame_;
-
   state_message.admittance_rule_calculated_values = admittance_rule_calculated_values_;
 
   state_message.current_pose = current_pose_ik_base_frame_;
   state_message.desired_pose = admittance_pose_ik_base_frame_;
-  state_message.relative_desired_pose = relative_admittance_pose_;
+  state_message.relative_desired_pose = relative_admittance_pose_ik_base_frame_;
 
   return controller_interface::return_type::OK;
 }
@@ -401,8 +281,9 @@ void AdmittanceRule::process_wrench_measurements(
   measured_wrench_.wrench = measured_wrench;
   filter_chain_->update(measured_wrench_, measured_wrench_filtered_);
 
-  // TODO(andyz): This is not flexible to work in other control frames besides ik_base
-  transform_message_to_ik_base_frame(measured_wrench_filtered_, measured_wrench_ik_base_frame_);
+  // TODO(destogl): rename this variables...
+  transform_to_ik_base_frame(measured_wrench_filtered_, measured_wrench_ik_base_frame_);
+  transform_to_control_frame(measured_wrench_filtered_, measured_wrench_ik_base_frame_);
   convert_message_to_array(measured_wrench_ik_base_frame_, measured_wrench_ik_base_frame_arr_);
 
   // TODO(destogl): optimize this checks!
@@ -456,17 +337,16 @@ void AdmittanceRule::calculate_admittance_rule(
 
 controller_interface::return_type AdmittanceRule::calculate_desired_joint_state(
   const trajectory_msgs::msg::JointTrajectoryPoint & current_joint_state,
+  const std::array<double, 6> & relative_pose,
   const rclcpp::Duration & period,
   trajectory_msgs::msg::JointTrajectoryPoint & desired_joint_state
 )
 {
-  convert_array_to_message(relative_admittance_pose_arr_, relative_admittance_pose_);
-
   // Since ik_base is MoveIt's working frame, the transform is identity.
   identity_transform_.header.frame_id = ik_base_frame_;
 
   // Use Jacobian-based IK
-  std::vector<double> relative_admittance_pose_vec(relative_admittance_pose_arr_.begin(), relative_admittance_pose_arr_.end());
+  std::vector<double> relative_admittance_pose_vec(relative_pose.begin(), relative_pose.end());
   ik_->update_robot_state(current_joint_state);
   if (ik_->convert_cartesian_deltas_to_joint_deltas(
     relative_admittance_pose_vec, identity_transform_, relative_desired_joint_state_vec_)){

--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -312,11 +312,11 @@ void AdmittanceRule::calculate_admittance_rule(
 {
   // Compute admittance control law: F = M*a + D*v + S*(x - x_d)
   for (auto i = 0u; i < 6; ++i) {
-    if (selected_axes_[i]) {
+    if (dynamic_param_.selected_axes_[i]) {
       // TODO(destogl): check if velocity is measured from hardware
-      const double admittance_acceleration = (1 / mass_[i]) * (measured_wrench[i] -
-                                             damping_[i] * admittance_velocity_arr_[i] -
-                                             stiffness_[i] * pose_error[i]);
+      const double admittance_acceleration = (1 / dynamic_param_.mass_[i]) * (measured_wrench[i] -
+                                             dynamic_param_.damping_[i] * admittance_velocity_arr_[i] -
+                                             dynamic_param_.stiffness_[i] * pose_error[i]);
 
       admittance_velocity_arr_[i] += admittance_acceleration * period.seconds();
 

--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -312,11 +312,11 @@ void AdmittanceRule::calculate_admittance_rule(
 {
   // Compute admittance control law: F = M*a + D*v + S*(x - x_d)
   for (auto i = 0u; i < 6; ++i) {
-    if (dynamic_param_.selected_axes_[i]) {
+    if ( parameters_.selected_axes_[i]) {
       // TODO(destogl): check if velocity is measured from hardware
-      const double admittance_acceleration = (1 / dynamic_param_.mass_[i]) * (measured_wrench[i] -
-                                             dynamic_param_.damping_[i] * admittance_velocity_arr_[i] -
-                                             dynamic_param_.stiffness_[i] * pose_error[i]);
+      const double admittance_acceleration = (1 / parameters_.mass_[i]) * (measured_wrench[i] -
+                                                   parameters_.damping_[i] * admittance_velocity_arr_[i] -
+                                                   parameters_.stiffness_[i] * pose_error[i]);
 
       admittance_velocity_arr_[i] += admittance_acceleration * period.seconds();
 

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -58,15 +58,15 @@ controller_interface::return_type AdmittanceController::init(const std::string &
     get_node()->declare_parameter<std::vector<std::string>>("state_interfaces", {});
     get_node()->declare_parameter<std::string>("ft_sensor_name", "");
     get_node()->declare_parameter<bool>("use_joint_commands_as_input", false);
-    get_node()->declare_parameter<bool>("open_loop_control", false);
+//     get_node()->declare_parameter<bool>("open_loop_control", false);
 
-    get_node()->declare_parameter<std::string>("IK.base", "");
-    // TODO(destogl): enable when IK-plugin support is added
-//     get_node()->declare_parameter<std::string>("IK.plugin", "");
-    get_node()->declare_parameter<std::string>("IK.group_name", "");
-
-    get_node()->declare_parameter<std::string>("control_frame", "");
-    get_node()->declare_parameter<std::string>("sensor_frame", "");
+//     get_node()->declare_parameter<std::string>("IK.base", "");
+//     // TODO(destogl): enable when IK-plugin support is added
+// //     get_node()->declare_parameter<std::string>("IK.plugin", "");
+//     get_node()->declare_parameter<std::string>("IK.group_name", "");
+//
+//     get_node()->declare_parameter<std::string>("control_frame", "");
+//     get_node()->declare_parameter<std::string>("sensor_frame", "");
 
     admittance_->parameters_.declare_parameters(get_node());
 
@@ -114,11 +114,11 @@ CallbackReturn AdmittanceController::on_configure(
     get_string_array_param_and_error_if_empty(state_interface_types_, "state_interfaces") ||
     get_string_param_and_error_if_empty(ft_sensor_name_, "ft_sensor_name") ||
     get_bool_param_and_error_if_empty(use_joint_commands_as_input_, "use_joint_commands_as_input") ||
-    get_bool_param_and_error_if_empty(admittance_->open_loop_control_, "open_loop_control") ||
-    get_string_param_and_error_if_empty(admittance_->ik_base_frame_, "IK.base") ||
-    get_string_param_and_error_if_empty(admittance_->ik_group_name_, "IK.group_name") ||
-    get_string_param_and_error_if_empty(admittance_->control_frame_, "control_frame") ||
-    get_string_param_and_error_if_empty(admittance_->sensor_frame_, "sensor_frame") ||
+//     get_bool_param_and_error_if_empty(admittance_->open_loop_control_, "open_loop_control") ||
+//     get_string_param_and_error_if_empty(admittance_->ik_base_frame_, "IK.base") ||
+//     get_string_param_and_error_if_empty(admittance_->ik_group_name_, "IK.group_name") ||
+//     get_string_param_and_error_if_empty(admittance_->control_frame_, "control_frame") ||
+//     get_string_param_and_error_if_empty(admittance_->sensor_frame_, "sensor_frame") ||
 
       !admittance_->parameters_.get_parameters(get_node())
     )
@@ -386,7 +386,7 @@ CallbackReturn AdmittanceController::on_activate(const rclcpp_lifecycle::State &
 
   // Set initial command values - initialize all to simplify update
   std::shared_ptr<ControllerCommandWrenchMsg> msg_wrench = std::make_shared<ControllerCommandWrenchMsg>();
-  msg_wrench->header.frame_id = admittance_->control_frame_;
+  msg_wrench->header.frame_id = admittance_->parameters_.control_frame_;
   input_wrench_command_.writeFromNonRT(msg_wrench);
 
   std::shared_ptr<ControllerCommandJointMsg> msg_joint = std::make_shared<ControllerCommandJointMsg>();
@@ -405,13 +405,13 @@ CallbackReturn AdmittanceController::on_activate(const rclcpp_lifecycle::State &
   input_joint_command_.writeFromNonRT(msg_joint);
 
   std::shared_ptr<ControllerCommandPoseMsg> msg_pose = std::make_shared<ControllerCommandPoseMsg>();
-  msg_pose->header.frame_id = admittance_->control_frame_;
+  msg_pose->header.frame_id = admittance_->parameters_.control_frame_;
   if (admittance_->get_pose_of_control_frame_in_base_frame(*msg_pose) !=
       controller_interface::return_type::OK)
   {
     RCLCPP_ERROR(node_->get_logger(),
                  "Can not find transform from '%s' to '%s' needed in the update loop",
-                 admittance_->ik_base_frame_, admittance_->control_frame_);
+                 admittance_->parameters_.ik_base_frame_, admittance_->parameters_.control_frame_);
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
   }
   input_pose_command_.writeFromNonRT(msg_pose);
@@ -456,7 +456,7 @@ controller_interface::return_type AdmittanceController::update()
 
   read_state_from_hardware(current_joint_states);
 
-  if (admittance_->open_loop_control_) {
+  if (admittance_->parameters_.open_loop_control_) {
     // TODO(destogl): This may not work in every case.
     // Please add checking which states are available and which not!
     current_joint_states = last_commanded_state_;

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -68,44 +68,7 @@ controller_interface::return_type AdmittanceController::init(const std::string &
     get_node()->declare_parameter<std::string>("control_frame", "");
     get_node()->declare_parameter<std::string>("sensor_frame", "");
 
-    // TODO(destogl): enable when force/position control is implemented
-//     get_node()->declare_parameter<bool>("admitance.unified_mode", false);
-//     get_node()->declare_parameter<bool>("admittance.selected_axes.x", false);
-//     get_node()->declare_parameter<bool>("admittance.selected_axes.y", false);
-//     get_node()->declare_parameter<bool>("admittance.selected_axes.z", false);
-//     get_node()->declare_parameter<bool>("admittance.selected_axes.rx", false);
-//     get_node()->declare_parameter<bool>("admittance.selected_axes.ry", false);
-//     get_node()->declare_parameter<bool>("admittance.selected_axes.rz", false);
-// 
-//     get_node()->declare_parameter<double>("admittance.mass.x", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.mass.y", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.mass.z", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.mass.rx", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.mass.ry", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.mass.rz", std::numeric_limits<double>::quiet_NaN());
-// 
-//     get_node()->declare_parameter<double>("admittance.damping.x", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping.y", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping.z", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping.rx", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping.ry", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping.rz", std::numeric_limits<double>::quiet_NaN());
-// 
-//     get_node()->declare_parameter<double>("admittance.damping_ratio.x", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping_ratio.y", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping_ratio.z", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping_ratio.rx", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping_ratio.ry", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.damping_ratio.rz", std::numeric_limits<double>::quiet_NaN());
-// 
-//     get_node()->declare_parameter<double>("admittance.stiffness.x", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.stiffness.y", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.stiffness.z", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.stiffness.rx", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.stiffness.ry", std::numeric_limits<double>::quiet_NaN());
-//     get_node()->declare_parameter<double>("admittance.stiffness.rz", std::numeric_limits<double>::quiet_NaN());
-    
-    admittance_->dynamic_param_.declare_parameters(get_node());
+    admittance_->parameters_.declare_parameters(get_node());
 
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
@@ -145,29 +108,6 @@ CallbackReturn AdmittanceController::on_configure(
     return false; // TODO(destogl): how to check "if_empty" for bool?
   };
 
-//   auto get_double_param_and_error_if_empty = [&](
-//     double & parameter, const char * parameter_name) {
-//     parameter = get_node()->get_parameter(parameter_name).get_value<double>();
-//     if (std::isnan(parameter)) {
-//       RCLCPP_ERROR(get_node()->get_logger(), "'%s' parameter was not set", parameter_name);
-//       return true;
-//     }
-//     return false;
-//   };
-
-//   auto get_double_params_and_error_if_both_empty_or_set = [&](
-//     double & parameter, const char * parameter_name,
-//     double & parameter2, const char * parameter_name2) {
-//     parameter = get_node()->get_parameter(parameter_name).get_value<double>();
-//     parameter2 = get_node()->get_parameter(parameter_name2).get_value<double>();
-//     if (std::isnan(parameter) == std::isnan(parameter2)) {
-//       RCLCPP_ERROR(get_node()->get_logger(), "'%s' and '%s' parameters were both '%s'set",
-//                    parameter_name, parameter_name2, (std::isnan(parameter) ? "not " : ""));
-//       return true;
-//     }
-//     return false;
-//     };
-
   if (
     get_string_array_param_and_error_if_empty(joint_names_, "joints") ||
     get_string_array_param_and_error_if_empty(command_interface_types_, "command_interfaces") ||
@@ -180,51 +120,10 @@ CallbackReturn AdmittanceController::on_configure(
     get_string_param_and_error_if_empty(admittance_->control_frame_, "control_frame") ||
     get_string_param_and_error_if_empty(admittance_->sensor_frame_, "sensor_frame") ||
 
-//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[0], "admittance.selected_axes.x") ||
-//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[1], "admittance.selected_axes.y") ||
-//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[2], "admittance.selected_axes.z") ||
-//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[3], "admittance.selected_axes.rx") ||
-//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[4], "admittance.selected_axes.ry") ||
-//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[5], "admittance.selected_axes.rz") ||
-// 
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[0], "admittance.mass.x") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[1], "admittance.mass.y") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[2], "admittance.mass.z") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[3], "admittance.mass.rx") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[4], "admittance.mass.ry") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[5], "admittance.mass.rz") ||
-// 
-//     get_double_params_and_error_if_both_empty_or_set(
-//       admittance_->dynamic_param_.damping_[0], "admittance.damping.x",
-//       admittance_->dynamic_param_.damping_ratio_[0], "admittance.damping_ratio.x") ||
-//     get_double_params_and_error_if_both_empty_or_set(
-//       admittance_->dynamic_param_.damping_[1], "admittance.damping.y",
-//       admittance_->dynamic_param_.damping_ratio_[1], "admittance.damping_ratio.y") ||
-//     get_double_params_and_error_if_both_empty_or_set(
-//       admittance_->dynamic_param_.damping_[2], "admittance.damping.z",
-//       admittance_->dynamic_param_.damping_ratio_[2], "admittance.damping_ratio.z") ||
-//     get_double_params_and_error_if_both_empty_or_set(
-//       admittance_->dynamic_param_.damping_[3], "admittance.damping.rx",
-//       admittance_->dynamic_param_.damping_ratio_[3], "admittance.damping_ratio.rx") ||
-//     get_double_params_and_error_if_both_empty_or_set(
-//       admittance_->dynamic_param_.damping_[4], "admittance.damping.ry",
-//       admittance_->dynamic_param_.damping_ratio_[4], "admittance.damping_ratio.ry") ||
-//     get_double_params_and_error_if_both_empty_or_set(
-//       admittance_->dynamic_param_.damping_[5], "admittance.damping.rz",
-//       admittance_->dynamic_param_.damping_ratio_[5], "admittance.damping_ratio.rz") ||
-// 
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[0], "admittance.stiffness.x") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[1], "admittance.stiffness.y") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[2], "admittance.stiffness.z") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[3], "admittance.stiffness.rx") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[4], "admittance.stiffness.ry") ||
-//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[5], "admittance.stiffness.rz")
-
-      !admittance_->dynamic_param_.get_parameters(get_node())
+      !admittance_->parameters_.get_parameters(get_node())
     )
   {
-    RCLCPP_ERROR(get_node()->get_logger(),
-                 "Error happend during reading parameters");
+    RCLCPP_ERROR(get_node()->get_logger(), "Error happend during reading parameters");
     return CallbackReturn::ERROR;
   }
 
@@ -390,33 +289,7 @@ CallbackReturn AdmittanceController::on_configure(
   on_set_callback_handle_ = get_node()->add_on_set_parameters_callback(
     [this](const std::vector<rclcpp::Parameter> & parameters) {
 
-      return admittance_->dynamic_param_.set_parameter_callback(parameters);
-//       // Mark parameters as updated
-//       auto result = rcl_interfaces::msg::SetParametersResult();
-//       bool dynamic_parameter_changed_ = false;
-//       for (const auto & parameter : parameters) {
-//         if (
-//           admittance_->dynamic_param_.selected_axes_map_.find(parameter.get_name()) !=
-//           admittance_->dynamic_param_.selected_axes_map_.end()) {
-//           admittance_->dynamic_param_.selected_axes_map_[parameter.get_name()].second = true;
-//           dynamic_parameter_changed_ = true;
-//         }
-//         if (
-//           admittance_->dynamic_param_.mass_stiffness_damping_map_.find(parameter.get_name()) !=
-//           admittance_->dynamic_param_.mass_stiffness_damping_map_.end()) {
-//           admittance_->dynamic_param_.mass_stiffness_damping_map_[parameter.get_name()].second =
-//             true;
-//           dynamic_parameter_changed_ = true;
-//         }
-//       }
-//       if (dynamic_parameter_changed_) {
-//         RCLCPP_INFO(
-//           get_node()->get_logger(),
-//           "Dynamic admittance parameters got changed! To update the parameters internally please "
-//           "restart the controller.");
-//       }
-//       result.successful = true;
-//       return result;
+      return admittance_->parameters_.set_parameter_callback(parameters);
     });
 
   RCLCPP_INFO(get_node()->get_logger(), "configure successful");
@@ -463,12 +336,11 @@ CallbackReturn AdmittanceController::on_activate(const rclcpp_lifecycle::State &
   const auto num_joints = joint_names_.size();
 
   // Update dynamic parameters before controller is started
-  if (!admittance_->dynamic_param_.check_if_parameters_are_valid()) {
-    RCLCPP_ERROR(get_node()->get_logger(), "Parameters are not valid and therefore will not be udpated");
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  if (!admittance_->parameters_.check_if_parameters_are_valid()) {
+    RCLCPP_WARN(get_node()->get_logger(),
+                "Parameters are not valid and therefore will not be udpated");
   } else {
-    RCLCPP_ERROR(get_node()->get_logger(), "Parameters are valid!");
-    admittance_->dynamic_param_.update();
+    admittance_->parameters_.update();
   }
   // Convert the damping ratio (if given) to mass/spring/damper representation
   admittance_->convert_damping_ratio_to_damping();

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -68,40 +68,42 @@ controller_interface::return_type AdmittanceController::init(const std::string &
 
     // TODO(destogl): enable when force/position control is implemented
 //     get_node()->declare_parameter<bool>("admitance.unified_mode", false);
-    get_node()->declare_parameter<bool>("admittance.selected_axes.x", false);
-    get_node()->declare_parameter<bool>("admittance.selected_axes.y", false);
-    get_node()->declare_parameter<bool>("admittance.selected_axes.z", false);
-    get_node()->declare_parameter<bool>("admittance.selected_axes.rx", false);
-    get_node()->declare_parameter<bool>("admittance.selected_axes.ry", false);
-    get_node()->declare_parameter<bool>("admittance.selected_axes.rz", false);
-
-    get_node()->declare_parameter<double>("admittance.mass.x", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.mass.y", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.mass.z", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.mass.rx", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.mass.ry", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.mass.rz", std::numeric_limits<double>::quiet_NaN());
-
-    get_node()->declare_parameter<double>("admittance.damping.x", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping.y", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping.z", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping.rx", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping.ry", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping.rz", std::numeric_limits<double>::quiet_NaN());
-
-    get_node()->declare_parameter<double>("admittance.damping_ratio.x", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping_ratio.y", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping_ratio.z", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping_ratio.rx", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping_ratio.ry", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.damping_ratio.rz", std::numeric_limits<double>::quiet_NaN());
-
-    get_node()->declare_parameter<double>("admittance.stiffness.x", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.stiffness.y", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.stiffness.z", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.stiffness.rx", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.stiffness.ry", std::numeric_limits<double>::quiet_NaN());
-    get_node()->declare_parameter<double>("admittance.stiffness.rz", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<bool>("admittance.selected_axes.x", false);
+//     get_node()->declare_parameter<bool>("admittance.selected_axes.y", false);
+//     get_node()->declare_parameter<bool>("admittance.selected_axes.z", false);
+//     get_node()->declare_parameter<bool>("admittance.selected_axes.rx", false);
+//     get_node()->declare_parameter<bool>("admittance.selected_axes.ry", false);
+//     get_node()->declare_parameter<bool>("admittance.selected_axes.rz", false);
+// 
+//     get_node()->declare_parameter<double>("admittance.mass.x", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.mass.y", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.mass.z", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.mass.rx", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.mass.ry", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.mass.rz", std::numeric_limits<double>::quiet_NaN());
+// 
+//     get_node()->declare_parameter<double>("admittance.damping.x", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping.y", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping.z", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping.rx", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping.ry", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping.rz", std::numeric_limits<double>::quiet_NaN());
+// 
+//     get_node()->declare_parameter<double>("admittance.damping_ratio.x", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping_ratio.y", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping_ratio.z", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping_ratio.rx", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping_ratio.ry", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.damping_ratio.rz", std::numeric_limits<double>::quiet_NaN());
+// 
+//     get_node()->declare_parameter<double>("admittance.stiffness.x", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.stiffness.y", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.stiffness.z", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.stiffness.rx", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.stiffness.ry", std::numeric_limits<double>::quiet_NaN());
+//     get_node()->declare_parameter<double>("admittance.stiffness.rz", std::numeric_limits<double>::quiet_NaN());
+    
+    admittance_->dynamic_param_.declare_parameters(get_node());
 
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
@@ -143,28 +145,28 @@ CallbackReturn AdmittanceController::on_configure(
     return false; // TODO(destogl): how to check "if_empty" for bool?
   };
 
-  auto get_double_param_and_error_if_empty = [&](
-    double & parameter, const char * parameter_name) {
-    parameter = get_node()->get_parameter(parameter_name).get_value<double>();
-    if (std::isnan(parameter)) {
-      RCLCPP_ERROR(get_node()->get_logger(), "'%s' parameter was not set", parameter_name);
-      return true;
-    }
-    return false;
-  };
+//   auto get_double_param_and_error_if_empty = [&](
+//     double & parameter, const char * parameter_name) {
+//     parameter = get_node()->get_parameter(parameter_name).get_value<double>();
+//     if (std::isnan(parameter)) {
+//       RCLCPP_ERROR(get_node()->get_logger(), "'%s' parameter was not set", parameter_name);
+//       return true;
+//     }
+//     return false;
+//   };
 
-  auto get_double_params_and_error_if_both_empty_or_set = [&](
-    double & parameter, const char * parameter_name,
-    double & parameter2, const char * parameter_name2) {
-    parameter = get_node()->get_parameter(parameter_name).get_value<double>();
-    parameter2 = get_node()->get_parameter(parameter_name2).get_value<double>();
-    if (std::isnan(parameter) == std::isnan(parameter2)) {
-      RCLCPP_ERROR(get_node()->get_logger(), "'%s' and '%s' parameters were both '%s'set",
-                   parameter_name, parameter_name2, (std::isnan(parameter) ? "not " : ""));
-      return true;
-    }
-    return false;
-    };
+//   auto get_double_params_and_error_if_both_empty_or_set = [&](
+//     double & parameter, const char * parameter_name,
+//     double & parameter2, const char * parameter_name2) {
+//     parameter = get_node()->get_parameter(parameter_name).get_value<double>();
+//     parameter2 = get_node()->get_parameter(parameter_name2).get_value<double>();
+//     if (std::isnan(parameter) == std::isnan(parameter2)) {
+//       RCLCPP_ERROR(get_node()->get_logger(), "'%s' and '%s' parameters were both '%s'set",
+//                    parameter_name, parameter_name2, (std::isnan(parameter) ? "not " : ""));
+//       return true;
+//     }
+//     return false;
+//     };
 
   if (
     get_string_array_param_and_error_if_empty(joint_names_, "joints") ||
@@ -178,45 +180,47 @@ CallbackReturn AdmittanceController::on_configure(
     get_string_param_and_error_if_empty(admittance_->control_frame_, "control_frame") ||
     get_string_param_and_error_if_empty(admittance_->sensor_frame_, "sensor_frame") ||
 
-    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[0], "admittance.selected_axes.x") ||
-    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[1], "admittance.selected_axes.y") ||
-    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[2], "admittance.selected_axes.z") ||
-    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[3], "admittance.selected_axes.rx") ||
-    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[4], "admittance.selected_axes.ry") ||
-    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[5], "admittance.selected_axes.rz") ||
+//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[0], "admittance.selected_axes.x") ||
+//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[1], "admittance.selected_axes.y") ||
+//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[2], "admittance.selected_axes.z") ||
+//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[3], "admittance.selected_axes.rx") ||
+//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[4], "admittance.selected_axes.ry") ||
+//     get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[5], "admittance.selected_axes.rz") ||
+// 
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[0], "admittance.mass.x") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[1], "admittance.mass.y") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[2], "admittance.mass.z") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[3], "admittance.mass.rx") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[4], "admittance.mass.ry") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[5], "admittance.mass.rz") ||
+// 
+//     get_double_params_and_error_if_both_empty_or_set(
+//       admittance_->dynamic_param_.damping_[0], "admittance.damping.x",
+//       admittance_->dynamic_param_.damping_ratio_[0], "admittance.damping_ratio.x") ||
+//     get_double_params_and_error_if_both_empty_or_set(
+//       admittance_->dynamic_param_.damping_[1], "admittance.damping.y",
+//       admittance_->dynamic_param_.damping_ratio_[1], "admittance.damping_ratio.y") ||
+//     get_double_params_and_error_if_both_empty_or_set(
+//       admittance_->dynamic_param_.damping_[2], "admittance.damping.z",
+//       admittance_->dynamic_param_.damping_ratio_[2], "admittance.damping_ratio.z") ||
+//     get_double_params_and_error_if_both_empty_or_set(
+//       admittance_->dynamic_param_.damping_[3], "admittance.damping.rx",
+//       admittance_->dynamic_param_.damping_ratio_[3], "admittance.damping_ratio.rx") ||
+//     get_double_params_and_error_if_both_empty_or_set(
+//       admittance_->dynamic_param_.damping_[4], "admittance.damping.ry",
+//       admittance_->dynamic_param_.damping_ratio_[4], "admittance.damping_ratio.ry") ||
+//     get_double_params_and_error_if_both_empty_or_set(
+//       admittance_->dynamic_param_.damping_[5], "admittance.damping.rz",
+//       admittance_->dynamic_param_.damping_ratio_[5], "admittance.damping_ratio.rz") ||
+// 
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[0], "admittance.stiffness.x") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[1], "admittance.stiffness.y") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[2], "admittance.stiffness.z") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[3], "admittance.stiffness.rx") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[4], "admittance.stiffness.ry") ||
+//     get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[5], "admittance.stiffness.rz")
 
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[0], "admittance.mass.x") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[1], "admittance.mass.y") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[2], "admittance.mass.z") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[3], "admittance.mass.rx") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[4], "admittance.mass.ry") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[5], "admittance.mass.rz") ||
-
-    get_double_params_and_error_if_both_empty_or_set(
-      admittance_->dynamic_param_.damping_[0], "admittance.damping.x",
-      admittance_->dynamic_param_.damping_ratio_[0], "admittance.damping_ratio.x") ||
-    get_double_params_and_error_if_both_empty_or_set(
-      admittance_->dynamic_param_.damping_[1], "admittance.damping.y",
-      admittance_->dynamic_param_.damping_ratio_[1], "admittance.damping_ratio.y") ||
-    get_double_params_and_error_if_both_empty_or_set(
-      admittance_->dynamic_param_.damping_[2], "admittance.damping.z",
-      admittance_->dynamic_param_.damping_ratio_[2], "admittance.damping_ratio.z") ||
-    get_double_params_and_error_if_both_empty_or_set(
-      admittance_->dynamic_param_.damping_[3], "admittance.damping.rx",
-      admittance_->dynamic_param_.damping_ratio_[3], "admittance.damping_ratio.rx") ||
-    get_double_params_and_error_if_both_empty_or_set(
-      admittance_->dynamic_param_.damping_[4], "admittance.damping.ry",
-      admittance_->dynamic_param_.damping_ratio_[4], "admittance.damping_ratio.ry") ||
-    get_double_params_and_error_if_both_empty_or_set(
-      admittance_->dynamic_param_.damping_[5], "admittance.damping.rz",
-      admittance_->dynamic_param_.damping_ratio_[5], "admittance.damping_ratio.rz") ||
-
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[0], "admittance.stiffness.x") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[1], "admittance.stiffness.y") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[2], "admittance.stiffness.z") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[3], "admittance.stiffness.rx") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[4], "admittance.stiffness.ry") ||
-    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[5], "admittance.stiffness.rz")
+      admittance_->dynamic_param_.get_parameters(get_node())
     )
   {
     return CallbackReturn::ERROR;
@@ -225,32 +229,34 @@ CallbackReturn AdmittanceController::on_configure(
   // Add callback to dynamically update parameters
   on_set_callback_handle_ = get_node()->add_on_set_parameters_callback(
     [this](const std::vector<rclcpp::Parameter> & parameters) {
-      // Mark parameters as updated
-      auto result = rcl_interfaces::msg::SetParametersResult();
-      bool dynamic_parameter_changed_ = false;
-      for (const auto & parameter : parameters) {
-        if (
-          admittance_->dynamic_param_.selected_axes_map_.find(parameter.get_name()) !=
-          admittance_->dynamic_param_.selected_axes_map_.end()) {
-          admittance_->dynamic_param_.selected_axes_map_[parameter.get_name()].second = true;
-          dynamic_parameter_changed_ = true;
-        }
-        if (
-          admittance_->dynamic_param_.mass_stiffness_damping_map_.find(parameter.get_name()) !=
-          admittance_->dynamic_param_.mass_stiffness_damping_map_.end()) {
-          admittance_->dynamic_param_.mass_stiffness_damping_map_[parameter.get_name()].second =
-            true;
-          dynamic_parameter_changed_ = true;
-        }
-      }
-      if (dynamic_parameter_changed_) {
-        RCLCPP_INFO(
-          get_node()->get_logger(),
-          "Dynamic admittance parameters got changed! To update the parameters internally please "
-          "restart the controller.");
-      }
-      result.successful = true;
-      return result;
+      
+      return admittance_->dynamic_param_.set_parameter_callback(get_node(), parameters);
+//       // Mark parameters as updated
+//       auto result = rcl_interfaces::msg::SetParametersResult();
+//       bool dynamic_parameter_changed_ = false;
+//       for (const auto & parameter : parameters) {
+//         if (
+//           admittance_->dynamic_param_.selected_axes_map_.find(parameter.get_name()) !=
+//           admittance_->dynamic_param_.selected_axes_map_.end()) {
+//           admittance_->dynamic_param_.selected_axes_map_[parameter.get_name()].second = true;
+//           dynamic_parameter_changed_ = true;
+//         }
+//         if (
+//           admittance_->dynamic_param_.mass_stiffness_damping_map_.find(parameter.get_name()) !=
+//           admittance_->dynamic_param_.mass_stiffness_damping_map_.end()) {
+//           admittance_->dynamic_param_.mass_stiffness_damping_map_[parameter.get_name()].second =
+//             true;
+//           dynamic_parameter_changed_ = true;
+//         }
+//       }
+//       if (dynamic_parameter_changed_) {
+//         RCLCPP_INFO(
+//           get_node()->get_logger(),
+//           "Dynamic admittance parameters got changed! To update the parameters internally please "
+//           "restart the controller.");
+//       }
+//       result.successful = true;
+//       return result;
     });
 
   // Convert the damping ratio (if given) to mass/spring/damper representation
@@ -457,9 +463,11 @@ CallbackReturn AdmittanceController::on_activate(const rclcpp_lifecycle::State &
   const auto num_joints = joint_names_.size();
 
   // Update dynamic parameters before controller is started
-  if (!admittance_->dynamic_param_.update(get_node())) {
+  if (!admittance_->dynamic_param_.check_if_parameters_are_valid(get_node())) {
     RCLCPP_ERROR(get_node()->get_logger(), "Failed to update dynamic admittance parameter");
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  } else {
+    admittance_->dynamic_param_.update();
   }
 
   // order all joints in the storage

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -178,49 +178,80 @@ CallbackReturn AdmittanceController::on_configure(
     get_string_param_and_error_if_empty(admittance_->control_frame_, "control_frame") ||
     get_string_param_and_error_if_empty(admittance_->sensor_frame_, "sensor_frame") ||
 
-    get_bool_param_and_error_if_empty(admittance_->selected_axes_[0], "admittance.selected_axes.x") ||
-    get_bool_param_and_error_if_empty(admittance_->selected_axes_[1], "admittance.selected_axes.y") ||
-    get_bool_param_and_error_if_empty(admittance_->selected_axes_[2], "admittance.selected_axes.z") ||
-    get_bool_param_and_error_if_empty(admittance_->selected_axes_[3], "admittance.selected_axes.rx") ||
-    get_bool_param_and_error_if_empty(admittance_->selected_axes_[4], "admittance.selected_axes.ry") ||
-    get_bool_param_and_error_if_empty(admittance_->selected_axes_[5], "admittance.selected_axes.rz") ||
+    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[0], "admittance.selected_axes.x") ||
+    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[1], "admittance.selected_axes.y") ||
+    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[2], "admittance.selected_axes.z") ||
+    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[3], "admittance.selected_axes.rx") ||
+    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[4], "admittance.selected_axes.ry") ||
+    get_bool_param_and_error_if_empty(admittance_->dynamic_param_.selected_axes_[5], "admittance.selected_axes.rz") ||
 
-    get_double_param_and_error_if_empty(admittance_->mass_[0], "admittance.mass.x") ||
-    get_double_param_and_error_if_empty(admittance_->mass_[1], "admittance.mass.y") ||
-    get_double_param_and_error_if_empty(admittance_->mass_[2], "admittance.mass.z") ||
-    get_double_param_and_error_if_empty(admittance_->mass_[3], "admittance.mass.rx") ||
-    get_double_param_and_error_if_empty(admittance_->mass_[4], "admittance.mass.ry") ||
-    get_double_param_and_error_if_empty(admittance_->mass_[5], "admittance.mass.rz") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[0], "admittance.mass.x") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[1], "admittance.mass.y") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[2], "admittance.mass.z") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[3], "admittance.mass.rx") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[4], "admittance.mass.ry") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.mass_[5], "admittance.mass.rz") ||
 
     get_double_params_and_error_if_both_empty_or_set(
-      admittance_->damping_[0], "admittance.damping.x",
-      admittance_->damping_ratio_[0], "admittance.damping_ratio.x") ||
+      admittance_->dynamic_param_.damping_[0], "admittance.damping.x",
+      admittance_->dynamic_param_.damping_ratio_[0], "admittance.damping_ratio.x") ||
     get_double_params_and_error_if_both_empty_or_set(
-      admittance_->damping_[1], "admittance.damping.y",
-      admittance_->damping_ratio_[1], "admittance.damping_ratio.y") ||
+      admittance_->dynamic_param_.damping_[1], "admittance.damping.y",
+      admittance_->dynamic_param_.damping_ratio_[1], "admittance.damping_ratio.y") ||
     get_double_params_and_error_if_both_empty_or_set(
-      admittance_->damping_[2], "admittance.damping.z",
-      admittance_->damping_ratio_[2], "admittance.damping_ratio.z") ||
+      admittance_->dynamic_param_.damping_[2], "admittance.damping.z",
+      admittance_->dynamic_param_.damping_ratio_[2], "admittance.damping_ratio.z") ||
     get_double_params_and_error_if_both_empty_or_set(
-      admittance_->damping_[3], "admittance.damping.rx",
-      admittance_->damping_ratio_[3], "admittance.damping_ratio.rx") ||
+      admittance_->dynamic_param_.damping_[3], "admittance.damping.rx",
+      admittance_->dynamic_param_.damping_ratio_[3], "admittance.damping_ratio.rx") ||
     get_double_params_and_error_if_both_empty_or_set(
-      admittance_->damping_[4], "admittance.damping.ry",
-      admittance_->damping_ratio_[4], "admittance.damping_ratio.ry") ||
+      admittance_->dynamic_param_.damping_[4], "admittance.damping.ry",
+      admittance_->dynamic_param_.damping_ratio_[4], "admittance.damping_ratio.ry") ||
     get_double_params_and_error_if_both_empty_or_set(
-      admittance_->damping_[5], "admittance.damping.rz",
-      admittance_->damping_ratio_[5], "admittance.damping_ratio.rz") ||
+      admittance_->dynamic_param_.damping_[5], "admittance.damping.rz",
+      admittance_->dynamic_param_.damping_ratio_[5], "admittance.damping_ratio.rz") ||
 
-    get_double_param_and_error_if_empty(admittance_->stiffness_[0], "admittance.stiffness.x") ||
-    get_double_param_and_error_if_empty(admittance_->stiffness_[1], "admittance.stiffness.y") ||
-    get_double_param_and_error_if_empty(admittance_->stiffness_[2], "admittance.stiffness.z") ||
-    get_double_param_and_error_if_empty(admittance_->stiffness_[3], "admittance.stiffness.rx") ||
-    get_double_param_and_error_if_empty(admittance_->stiffness_[4], "admittance.stiffness.ry") ||
-    get_double_param_and_error_if_empty(admittance_->stiffness_[5], "admittance.stiffness.rz")
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[0], "admittance.stiffness.x") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[1], "admittance.stiffness.y") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[2], "admittance.stiffness.z") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[3], "admittance.stiffness.rx") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[4], "admittance.stiffness.ry") ||
+    get_double_param_and_error_if_empty(admittance_->dynamic_param_.stiffness_[5], "admittance.stiffness.rz")
     )
   {
     return CallbackReturn::ERROR;
   }
+
+  // Add callback to dynamically update parameters
+  on_set_callback_handle_ = get_node()->add_on_set_parameters_callback(
+    [this](const std::vector<rclcpp::Parameter> & parameters) {
+      // Mark parameters as updated
+      auto result = rcl_interfaces::msg::SetParametersResult();
+      bool dynamic_parameter_changed_ = false;
+      for (const auto & parameter : parameters) {
+        if (
+          admittance_->dynamic_param_.selected_axes_map_.find(parameter.get_name()) !=
+          admittance_->dynamic_param_.selected_axes_map_.end()) {
+          admittance_->dynamic_param_.selected_axes_map_[parameter.get_name()].second = true;
+          dynamic_parameter_changed_ = true;
+        }
+        if (
+          admittance_->dynamic_param_.mass_stiffness_damping_map_.find(parameter.get_name()) !=
+          admittance_->dynamic_param_.mass_stiffness_damping_map_.end()) {
+          admittance_->dynamic_param_.mass_stiffness_damping_map_[parameter.get_name()].second =
+            true;
+          dynamic_parameter_changed_ = true;
+        }
+      }
+      if (dynamic_parameter_changed_) {
+        RCLCPP_INFO(
+          get_node()->get_logger(),
+          "Dynamic admittance parameters got changed! To update the parameters internally please "
+          "restart the controller.");
+      }
+      result.successful = true;
+      return result;
+    });
 
   // Convert the damping ratio (if given) to mass/spring/damper representation
   admittance_->convert_damping_ratio_to_damping();
@@ -424,6 +455,12 @@ const
 CallbackReturn AdmittanceController::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   const auto num_joints = joint_names_.size();
+
+  // Update dynamic parameters before controller is started
+  if (!admittance_->dynamic_param_.update(get_node())) {
+    RCLCPP_ERROR(get_node()->get_logger(), "Failed to update dynamic admittance parameter");
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
 
   // order all joints in the storage
   for (const auto & interface : command_interface_types_) {

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -59,14 +59,11 @@ controller_interface::return_type AdmittanceController::init(const std::string &
     get_node()->declare_parameter<bool>("open_loop_control", false);
 
     get_node()->declare_parameter<std::string>("IK.base", "");
-    get_node()->declare_parameter<std::string>("IK.tip", "");
     // TODO(destogl): enable when IK-plugin support is added
 //     get_node()->declare_parameter<std::string>("IK.plugin", "");
     get_node()->declare_parameter<std::string>("IK.group_name", "");
 
     get_node()->declare_parameter<std::string>("control_frame", "");
-    get_node()->declare_parameter<std::string>("endeffector_frame", "");
-    get_node()->declare_parameter<std::string>("fixed_world_frame", "");
     get_node()->declare_parameter<std::string>("sensor_frame", "");
 
     // TODO(destogl): enable when force/position control is implemented
@@ -177,11 +174,8 @@ CallbackReturn AdmittanceController::on_configure(
     get_bool_param_and_error_if_empty(use_joint_commands_as_input_, "use_joint_commands_as_input") ||
     get_bool_param_and_error_if_empty(admittance_->open_loop_control_, "open_loop_control") ||
     get_string_param_and_error_if_empty(admittance_->ik_base_frame_, "IK.base") ||
-    get_string_param_and_error_if_empty(admittance_->ik_tip_frame_, "IK.tip") ||
     get_string_param_and_error_if_empty(admittance_->ik_group_name_, "IK.group_name") ||
-    get_string_param_and_error_if_empty(admittance_->endeffector_frame_, "endeffector_frame") ||
     get_string_param_and_error_if_empty(admittance_->control_frame_, "control_frame") ||
-    get_string_param_and_error_if_empty(admittance_->fixed_world_frame_, "fixed_world_frame") ||
     get_string_param_and_error_if_empty(admittance_->sensor_frame_, "sensor_frame") ||
 
     get_bool_param_and_error_if_empty(admittance_->selected_axes_[0], "admittance.selected_axes.x") ||

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -230,7 +230,7 @@ CallbackReturn AdmittanceController::on_configure(
   on_set_callback_handle_ = get_node()->add_on_set_parameters_callback(
     [this](const std::vector<rclcpp::Parameter> & parameters) {
       
-      return admittance_->dynamic_param_.set_parameter_callback(get_node(), parameters);
+      return admittance_->dynamic_param_.set_parameter_callback(parameters);
 //       // Mark parameters as updated
 //       auto result = rcl_interfaces::msg::SetParametersResult();
 //       bool dynamic_parameter_changed_ = false;
@@ -463,7 +463,7 @@ CallbackReturn AdmittanceController::on_activate(const rclcpp_lifecycle::State &
   const auto num_joints = joint_names_.size();
 
   // Update dynamic parameters before controller is started
-  if (!admittance_->dynamic_param_.check_if_parameters_are_valid(get_node())) {
+  if (!admittance_->dynamic_param_.check_if_parameters_are_valid()) {
     RCLCPP_ERROR(get_node()->get_logger(), "Failed to update dynamic admittance parameter");
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
   } else {

--- a/admittance_controller/test/test_admittance_controller.cpp
+++ b/admittance_controller/test/test_admittance_controller.cpp
@@ -206,28 +206,28 @@ TEST_F(AdmittanceControllerTest, all_parameters_set_configure_success)
   //   ASSERT_EQ(controller_->admittance_->ik_group_name_, ik_group_name_);
   ASSERT_EQ(controller_->admittance_->sensor_frame_, sensor_frame_);
 
-  ASSERT_TRUE(!controller_->admittance_->selected_axes_.empty());
-  ASSERT_TRUE(controller_->admittance_->selected_axes_.size() == admittance_selected_axes_.size());
+  ASSERT_TRUE(!controller_->admittance_->dynamic_param_.selected_axes_.empty());
+  ASSERT_TRUE(controller_->admittance_->dynamic_param_.selected_axes_.size() == admittance_selected_axes_.size());
   ASSERT_TRUE(std::equal(
-    controller_->admittance_->selected_axes_.begin(), controller_->admittance_->selected_axes_.end(),
+    controller_->admittance_->dynamic_param_.selected_axes_.begin(), controller_->admittance_->dynamic_param_.selected_axes_.end(),
                          admittance_selected_axes_.begin(), admittance_selected_axes_.end()));
 
-  ASSERT_TRUE(!controller_->admittance_->mass_.empty());
-  ASSERT_TRUE(controller_->admittance_->mass_.size() == admittance_mass_.size());
+  ASSERT_TRUE(!controller_->admittance_->dynamic_param_.mass_.empty());
+  ASSERT_TRUE(controller_->admittance_->dynamic_param_.mass_.size() == admittance_mass_.size());
   ASSERT_TRUE(std::equal(
-    controller_->admittance_->mass_.begin(), controller_->admittance_->mass_.end(),
+    controller_->admittance_->dynamic_param_.mass_.begin(), controller_->admittance_->dynamic_param_.mass_.end(),
                          admittance_mass_.begin(), admittance_mass_.end()));
 
-  ASSERT_TRUE(!controller_->admittance_->damping_.empty());
-  ASSERT_TRUE(controller_->admittance_->damping_.size() == admittance_damping_.size());
+  ASSERT_TRUE(!controller_->admittance_->dynamic_param_.damping_.empty());
+  ASSERT_TRUE(controller_->admittance_->dynamic_param_.damping_.size() == admittance_damping_.size());
   ASSERT_TRUE(std::equal(
-    controller_->admittance_->damping_.begin(), controller_->admittance_->damping_.end(),
+    controller_->admittance_->dynamic_param_.damping_.begin(), controller_->admittance_->dynamic_param_.damping_.end(),
                          admittance_damping_.begin(), admittance_damping_.end()));
 
-  ASSERT_TRUE(!controller_->admittance_->stiffness_.empty());
-  ASSERT_TRUE(controller_->admittance_->stiffness_.size() == admittance_stiffness_.size());
+  ASSERT_TRUE(!controller_->admittance_->dynamic_param_.stiffness_.empty());
+  ASSERT_TRUE(controller_->admittance_->dynamic_param_.stiffness_.size() == admittance_stiffness_.size());
   ASSERT_TRUE(std::equal(
-    controller_->admittance_->stiffness_.begin(), controller_->admittance_->stiffness_.end(),
+    controller_->admittance_->dynamic_param_.stiffness_.begin(), controller_->admittance_->dynamic_param_.stiffness_.end(),
                          admittance_stiffness_.begin(), admittance_stiffness_.end()));
 }
 

--- a/admittance_controller/test/test_admittance_controller.cpp
+++ b/admittance_controller/test/test_admittance_controller.cpp
@@ -64,19 +64,11 @@ INSTANTIATE_TEST_CASE_P(
       rclcpp::ParameterValue("")
     ),
     std::make_tuple(
-      std::string("IK.tip"),
-      rclcpp::ParameterValue("")
-    ),
-    std::make_tuple(
       std::string("IK.group_name"),
       rclcpp::ParameterValue("")
     ),
     std::make_tuple(
       std::string("control_frame"),
-      rclcpp::ParameterValue("")
-    ),
-    std::make_tuple(
-      std::string("fixed_world_frame"),
       rclcpp::ParameterValue("")
     ),
     std::make_tuple(
@@ -211,9 +203,7 @@ TEST_F(AdmittanceControllerTest, all_parameters_set_configure_success)
 
   ASSERT_EQ(controller_->ft_sensor_name_, ft_sensor_name_);
   ASSERT_EQ(controller_->admittance_->ik_base_frame_, ik_base_frame_);
-  ASSERT_EQ(controller_->admittance_->ik_tip_frame_, ik_tip_frame_);
   //   ASSERT_EQ(controller_->admittance_->ik_group_name_, ik_group_name_);
-  ASSERT_EQ(controller_->admittance_->fixed_world_frame_, fixed_world_frame_);
   ASSERT_EQ(controller_->admittance_->sensor_frame_, sensor_frame_);
 
   ASSERT_TRUE(!controller_->admittance_->selected_axes_.empty());

--- a/admittance_controller/test/test_admittance_controller.cpp
+++ b/admittance_controller/test/test_admittance_controller.cpp
@@ -202,32 +202,32 @@ TEST_F(AdmittanceControllerTest, all_parameters_set_configure_success)
                          state_interface_types_.begin(), state_interface_types_.end()));
 
   ASSERT_EQ(controller_->ft_sensor_name_, ft_sensor_name_);
-  ASSERT_EQ(controller_->admittance_->ik_base_frame_, ik_base_frame_);
-  //   ASSERT_EQ(controller_->admittance_->ik_group_name_, ik_group_name_);
-  ASSERT_EQ(controller_->admittance_->sensor_frame_, sensor_frame_);
+  ASSERT_EQ(controller_->admittance_->parameters_.ik_base_frame_, ik_base_frame_);
+  //   ASSERT_EQ(controller_->admittance_->parameters_.ik_group_name_, ik_group_name_);
+  ASSERT_EQ(controller_->admittance_->parameters_.sensor_frame_, sensor_frame_);
 
-  ASSERT_TRUE(!controller_->admittance_->dynamic_param_.selected_axes_.empty());
-  ASSERT_TRUE(controller_->admittance_->dynamic_param_.selected_axes_.size() == admittance_selected_axes_.size());
+  ASSERT_TRUE(!controller_->admittance_->parameters_.selected_axes_.empty());
+  ASSERT_TRUE(controller_->admittance_->parameters_.selected_axes_.size() == admittance_selected_axes_.size());
   ASSERT_TRUE(std::equal(
-    controller_->admittance_->dynamic_param_.selected_axes_.begin(), controller_->admittance_->dynamic_param_.selected_axes_.end(),
+    controller_->admittance_->parameters_.selected_axes_.begin(), controller_->admittance_->parameters_.selected_axes_.end(),
                          admittance_selected_axes_.begin(), admittance_selected_axes_.end()));
 
-  ASSERT_TRUE(!controller_->admittance_->dynamic_param_.mass_.empty());
-  ASSERT_TRUE(controller_->admittance_->dynamic_param_.mass_.size() == admittance_mass_.size());
+  ASSERT_TRUE(!controller_->admittance_->parameters_.mass_.empty());
+  ASSERT_TRUE(controller_->admittance_->parameters_.mass_.size() == admittance_mass_.size());
   ASSERT_TRUE(std::equal(
-    controller_->admittance_->dynamic_param_.mass_.begin(), controller_->admittance_->dynamic_param_.mass_.end(),
+    controller_->admittance_->parameters_.mass_.begin(), controller_->admittance_->parameters_.mass_.end(),
                          admittance_mass_.begin(), admittance_mass_.end()));
 
-  ASSERT_TRUE(!controller_->admittance_->dynamic_param_.damping_.empty());
-  ASSERT_TRUE(controller_->admittance_->dynamic_param_.damping_.size() == admittance_damping_.size());
+  ASSERT_TRUE(!controller_->admittance_->parameters_.damping_.empty());
+  ASSERT_TRUE(controller_->admittance_->parameters_.damping_.size() == admittance_damping_.size());
   ASSERT_TRUE(std::equal(
-    controller_->admittance_->dynamic_param_.damping_.begin(), controller_->admittance_->dynamic_param_.damping_.end(),
+    controller_->admittance_->parameters_.damping_.begin(), controller_->admittance_->parameters_.damping_.end(),
                          admittance_damping_.begin(), admittance_damping_.end()));
 
-  ASSERT_TRUE(!controller_->admittance_->dynamic_param_.stiffness_.empty());
-  ASSERT_TRUE(controller_->admittance_->dynamic_param_.stiffness_.size() == admittance_stiffness_.size());
+  ASSERT_TRUE(!controller_->admittance_->parameters_.stiffness_.empty());
+  ASSERT_TRUE(controller_->admittance_->parameters_.stiffness_.size() == admittance_stiffness_.size());
   ASSERT_TRUE(std::equal(
-    controller_->admittance_->dynamic_param_.stiffness_.begin(), controller_->admittance_->dynamic_param_.stiffness_.end(),
+    controller_->admittance_->parameters_.stiffness_.begin(), controller_->admittance_->parameters_.stiffness_.end(),
                          admittance_stiffness_.begin(), admittance_stiffness_.end()));
 }
 


### PR DESCRIPTION
Make admittance parameters reconfigurable at runtime. 
Change a ROS2 param via command-line interface during runtime  i.e.
```
ros2 param set /admittance_controller admittance.selected_axes.rx 'False'
```
and reactivate the controller afterward to update the value.