### PR TITLE
Move JTC action server and trajectory sampling into separate class

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -45,6 +45,8 @@
 #include "trajectory_msgs/msg/joint_trajectory.hpp"
 #include "trajectory_msgs/msg/joint_trajectory_point.hpp"
 
+#include "joint_trajectory_controller/trajectory_execution_impl.hpp"
+
 using namespace std::chrono_literals;  // NOLINT
 
 namespace rclcpp_action
@@ -61,7 +63,8 @@ namespace joint_trajectory_controller
 {
 class Trajectory;
 
-class JointTrajectoryController : public controller_interface::ControllerInterface
+class JointTrajectoryController : public controller_interface::ControllerInterface,
+                                  public joint_trajectory_controller::TrajectoryExecutionImpl
 {
 public:
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
@@ -161,18 +164,6 @@ protected:
   // https://github.com/ros-controls/ros_controllers/blob/noetic-devel/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h#L283
   bool use_closed_loop_pid_adapter = false;
 
-  // TODO(karsten1987): eventually activate and deactivate subscriber directly when its supported
-  bool subscriber_is_active_ = false;
-  rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr joint_command_subscriber_ =
-    nullptr;
-
-  std::shared_ptr<Trajectory> * traj_point_active_ptr_ = nullptr;
-  std::shared_ptr<Trajectory> traj_external_point_ptr_ = nullptr;
-  std::shared_ptr<Trajectory> traj_home_point_ptr_ = nullptr;
-  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> traj_msg_home_ptr_ = nullptr;
-  realtime_tools::RealtimeBuffer<std::shared_ptr<trajectory_msgs::msg::JointTrajectory>>
-    traj_msg_external_point_ptr_;
-
   // The controller should be in halted state after creation otherwise memory corruption
   // TODO(anyone): Is the variable relevant, since we are using lifecycle?
   bool is_halted_ = true;
@@ -187,57 +178,9 @@ protected:
     rclcpp::Duration::from_nanoseconds(RCUTILS_MS_TO_NS(20));
   rclcpp::Time last_state_publish_time_;
 
-  using FollowJTrajAction = control_msgs::action::FollowJointTrajectory;
-  using RealtimeGoalHandle = realtime_tools::RealtimeServerGoalHandle<FollowJTrajAction>;
-  using RealtimeGoalHandlePtr = std::shared_ptr<RealtimeGoalHandle>;
-  using RealtimeGoalHandleBuffer = realtime_tools::RealtimeBuffer<RealtimeGoalHandlePtr>;
-
-  rclcpp_action::Server<FollowJTrajAction>::SharedPtr action_server_;
   bool allow_partial_joints_goal_ = false;
-  RealtimeGoalHandleBuffer rt_active_goal_;  ///< Currently active action goal, if any.
-  rclcpp::TimerBase::SharedPtr goal_handle_timer_;
-  rclcpp::Duration action_monitor_period_ =
-    rclcpp::Duration::from_nanoseconds(RCUTILS_MS_TO_NS(50));
-
-  // callbacks for action_server_
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  rclcpp_action::GoalResponse goal_callback(
-    const rclcpp_action::GoalUUID & uuid, std::shared_ptr<const FollowJTrajAction::Goal> goal);
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  rclcpp_action::CancelResponse cancel_callback(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  void feedback_setup_callback(
-    std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
-
-  // fill trajectory_msg so it matches joints controlled by this controller
-  // positions set to current position, velocities, accelerations and efforts to 0.0
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  void fill_partial_goal(
-    std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg) const;
-  // sorts the joints of the incoming message to our local order
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  void sort_to_local_joint_order(
-    std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg);
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  bool validate_trajectory_msg(const trajectory_msgs::msg::JointTrajectory & trajectory) const;
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  void add_new_trajectory_msg(
-    const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & traj_msg);
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  bool validate_trajectory_point_field(
-    size_t joint_names_size, const std::vector<double> & vector_field,
-    const std::string & string_for_vector_field, size_t i, bool allow_empty) const;
 
   SegmentTolerances default_tolerances_;
-
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  void preempt_active_goal();
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  void set_hold_position();
-
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  bool reset();
 
   using JointTrajectoryPoint = trajectory_msgs::msg::JointTrajectoryPoint;
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
@@ -252,9 +195,6 @@ protected:
 private:
   bool contains_interface_type(
     const std::vector<std::string> & interface_type_list, const std::string & interface_type);
-
-  void resize_joint_trajectory_point(
-    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size);
 };
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory_execution_impl.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory_execution_impl.hpp
@@ -1,0 +1,611 @@
+// Copyright (c) 2021 ros2_control Development Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// #include "joint_trajectory_controller/joint_trajectory_controller.hpp"
+
+#ifndef JOINT_TRAJECTORY_CONTROLLER__TRAJECTORY_EXECUTION_IMPL_HPP_
+#define JOINT_TRAJECTORY_CONTROLLER__TRAJECTORY_EXECUTION_IMPL_HPP_
+
+// TODO: Clean up includes
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "control_msgs/action/follow_joint_trajectory.hpp"
+#include "control_msgs/msg/joint_trajectory_controller_state.hpp"
+#include "controller_interface/controller_interface.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "joint_limits/joint_limiter_interface.hpp"
+#include "joint_limits/joint_limits.hpp"
+#include "joint_trajectory_controller/tolerances.hpp"
+#include "joint_trajectory_controller/trajectory.hpp"
+#include "joint_trajectory_controller/visibility_control.h"
+#include "pluginlib/class_loader.hpp"
+#include "rclcpp/duration.hpp"
+#include "rclcpp/subscription.hpp"
+#include "rclcpp/time.hpp"
+#include "rclcpp/timer.hpp"
+#include "rclcpp_action/create_server.hpp"
+#include "rclcpp_action/server.hpp"
+#include "rclcpp_action/types.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+#include "realtime_tools/realtime_buffer.h"
+#include "realtime_tools/realtime_publisher.h"
+#include "realtime_tools/realtime_server_goal_handle.h"
+#include "trajectory_msgs/msg/joint_trajectory.hpp"
+#include "trajectory_msgs/msg/joint_trajectory_point.hpp"
+
+namespace joint_trajectory_controller
+{
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("trajectory_execution_impl");
+
+class TrajectoryExecutionImpl
+{
+public:
+  // TrajectoryExecutionImpl(const rclcpp::Node::SharedPtr& node)
+  //   : node_(node) {}
+
+protected:
+  using FollowJTrajAction = control_msgs::action::FollowJointTrajectory;
+  using RealtimeGoalHandle = realtime_tools::RealtimeServerGoalHandle<FollowJTrajAction>;
+  using RealtimeGoalHandlePtr = std::shared_ptr<RealtimeGoalHandle>;
+  using RealtimeGoalHandleBuffer = realtime_tools::RealtimeBuffer<RealtimeGoalHandlePtr>;
+  using JointLimiter = joint_limits::JointLimiterInterface<joint_limits::JointLimits>;
+
+  bool reset()
+  {
+    subscriber_is_active_ = false;
+    joint_command_subscriber_.reset();
+
+    // iterator has no default value
+    // prev_traj_point_ptr_;
+    traj_point_active_ptr_ = nullptr;
+    traj_external_point_ptr_.reset();
+    traj_home_point_ptr_.reset();
+    traj_msg_home_ptr_.reset();
+
+    return true;
+  }
+
+  void check_for_new_trajectory(
+    std::vector<std::string> joint_names,
+    std::vector<std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>>
+      joint_command_interface)
+  {
+    // Check if a new external message has been received from nonRT threads
+    auto current_external_msg = traj_external_point_ptr_->get_trajectory_msg();
+    auto new_external_msg = traj_msg_external_point_ptr_.readFromRT();
+    if (current_external_msg != *new_external_msg)
+    {
+      fill_partial_goal(*new_external_msg, joint_names, joint_command_interface);
+      sort_to_local_joint_order(*new_external_msg, joint_names);
+      traj_external_point_ptr_->update(*new_external_msg);
+    }
+  }
+
+  bool have_trajectory()
+  {
+    return traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_trajectory_msg();
+  }
+
+  void set_point_before_trajectory_msg(
+    bool open_loop_control, rclcpp::Time now,
+    trajectory_msgs::msg::JointTrajectoryPoint state_current,
+    trajectory_msgs::msg::JointTrajectoryPoint last_commanded_state)
+  {
+    // If we will be sampling for the first time, prefix the trajectory with the current state
+    // currently carrying out a trajectory
+    if (traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_trajectory_msg())
+    {
+      // if sampling the first time, set the point before you sample
+      if (!(*traj_point_active_ptr_)->is_sampled_already())
+      {
+        if (open_loop_control)
+        {
+          (*traj_point_active_ptr_)->set_point_before_trajectory_msg(now, last_commanded_state);
+        }
+        else
+        {
+          (*traj_point_active_ptr_)->set_point_before_trajectory_msg(now, state_current);
+        }
+      }
+    }
+  }
+
+  bool sample_trajectory(
+    const rclcpp::Time & now, trajectory_msgs::msg::JointTrajectoryPoint & state_desired,
+    TrajectoryPointConstIter & start_segment_itr, TrajectoryPointConstIter & end_segment_itr,
+    std::unique_ptr<JointLimiter> & joint_limiter)
+  {
+    return (*traj_point_active_ptr_)
+      ->sample(now, state_desired, start_segment_itr, end_segment_itr, joint_limiter);
+  }
+
+  bool is_before_last_point(TrajectoryPointConstIter & end_segment_itr)
+  {
+    return end_segment_itr != (*traj_point_active_ptr_)->end();
+  }
+
+  void perform_action_server_update(
+    bool before_last_point, bool abort, bool outside_state_tolerance, double goal_time_tolerance,
+    rclcpp::Time now, std::vector<std::string> joint_names,
+    trajectory_msgs::msg::JointTrajectoryPoint state_current,
+    trajectory_msgs::msg::JointTrajectoryPoint state_desired,
+    trajectory_msgs::msg::JointTrajectoryPoint state_error,
+    TrajectoryPointConstIter start_segment_itr)
+  {
+    const auto active_goal = *rt_active_goal_.readFromRT();
+    if (active_goal)
+    {
+      // send feedback
+      auto feedback = std::make_shared<FollowJTrajAction::Feedback>();
+      feedback->header.stamp = now;
+      feedback->joint_names = joint_names;
+
+      feedback->actual = state_current;
+      feedback->desired = state_desired;
+      feedback->error = state_error;
+      active_goal->setFeedback(feedback);
+
+      // check abort
+      if (abort || outside_state_tolerance)
+      {
+        auto result = std::make_shared<FollowJTrajAction::Result>();
+
+        if (abort)
+        {
+          RCLCPP_WARN(LOGGER, "Aborted due to state tolerance violation");
+          result->set__error_code(FollowJTrajAction::Result::PATH_TOLERANCE_VIOLATED);
+        }
+        else if (outside_state_tolerance)
+        {
+          RCLCPP_WARN(LOGGER, "Aborted due to goal tolerance violation");
+          result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
+        }
+        active_goal->setAborted(result);
+        // TODO(matthew-reynolds): Need a lock-free write here
+        // See https://github.com/ros-controls/ros2_controllers/issues/168
+        rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
+
+        // check goal tolerance
+      }
+      else if (!before_last_point)
+      {
+        if (!outside_state_tolerance)
+        {
+          auto res = std::make_shared<FollowJTrajAction::Result>();
+          res->set__error_code(FollowJTrajAction::Result::SUCCESSFUL);
+          active_goal->setSucceeded(res);
+          // TODO(matthew-reynolds): Need a lock-free write here
+          // See https://github.com/ros-controls/ros2_controllers/issues/168
+          rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
+
+          RCLCPP_INFO(LOGGER, "Goal reached, success!");
+        }
+        else if (goal_time_tolerance != 0.0)
+        {
+          // if we exceed goal_time_toleralance set it to aborted
+          const rclcpp::Time traj_start = (*traj_point_active_ptr_)->get_trajectory_start_time();
+          const rclcpp::Time traj_end = traj_start + start_segment_itr->time_from_start;
+
+          const double difference = now.seconds() - traj_end.seconds();
+          if (difference > goal_time_tolerance)
+          {
+            auto result = std::make_shared<FollowJTrajAction::Result>();
+            result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
+            active_goal->setAborted(result);
+            // TODO(matthew-reynolds): Need a lock-free write here
+            // See https://github.com/ros-controls/ros2_controllers/issues/168
+            rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
+            RCLCPP_WARN(
+              LOGGER, "Aborted due goal_time_tolerance exceeding by %f seconds", difference);
+          }
+        }
+      }
+    }
+  }
+
+  rclcpp_action::GoalResponse goal_callback(
+    // const rclcpp_action::GoalUUID &, std::shared_ptr<const FollowJTrajAction::Goal> goal)
+    const rclcpp_action::GoalUUID &, std::shared_ptr<const FollowJTrajAction::Goal> goal,
+    const controller_interface::ControllerInterface * controller_interface,
+    bool allow_partial_joints_goal, std::vector<std::string> joint_names,
+    bool allow_integration_in_goal_trajectories, rclcpp::Node::SharedPtr node)
+  {
+    RCLCPP_INFO(LOGGER, "Received new action goal");
+
+    // Precondition: Running controller
+    if (
+      controller_interface->get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+    {
+      RCLCPP_ERROR(LOGGER, "Can't accept new action goals. Controller is not running.");
+      return rclcpp_action::GoalResponse::REJECT;
+    }
+
+    if (!validate_trajectory_msg(
+          goal->trajectory, allow_partial_joints_goal, joint_names,
+          allow_integration_in_goal_trajectories, node->now()))
+    {
+      return rclcpp_action::GoalResponse::REJECT;
+    }
+
+    // TODO(denis): is here the following line missing?
+    //   add_new_trajectory_msg(std::make_shared(goal->trajectory));
+
+    RCLCPP_INFO(LOGGER, "Accepted new action goal");
+    return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+  }
+
+  rclcpp_action::CancelResponse cancel_callback(
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle)
+  {
+    RCLCPP_INFO(LOGGER, "Got request to cancel goal");
+
+    // Check that cancel request refers to currently active goal (if any)
+    const auto active_goal = *rt_active_goal_.readFromNonRT();
+    if (active_goal && active_goal->gh_ == goal_handle)
+    {
+      // Controller uptime
+      // Enter hold current position mode
+      set_hold_position();
+
+      RCLCPP_DEBUG(LOGGER, "Canceling active action goal because cancel callback received.");
+
+      // Mark the current goal as canceled
+      auto action_res = std::make_shared<FollowJTrajAction::Result>();
+      active_goal->setCanceled(action_res);
+      rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
+    }
+    return rclcpp_action::CancelResponse::ACCEPT;
+  }
+
+  void feedback_setup_callback(
+    // std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle)
+    std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle,
+    rclcpp::Node::SharedPtr node, std::vector<std::string> joint_names,
+    rclcpp::Duration action_monitor_period)
+  {
+    // Update new trajectory
+    {
+      preempt_active_goal();
+      auto traj_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>(
+        goal_handle->get_goal()->trajectory);
+
+      add_new_trajectory_msg(traj_msg);
+    }
+
+    // Update the active goal
+    RealtimeGoalHandlePtr rt_goal = std::make_shared<RealtimeGoalHandle>(goal_handle);
+    rt_goal->preallocated_feedback_->joint_names = joint_names;
+    rt_goal->execute();
+    rt_active_goal_.writeFromNonRT(rt_goal);
+
+    // Setup goal status checking timer
+    goal_handle_timer_ = node->create_wall_timer(
+      action_monitor_period.to_chrono<std::chrono::seconds>(),
+      std::bind(&RealtimeGoalHandle::runNonRealtime, rt_goal));
+  }
+
+  void create_action_server(
+    rclcpp::Node::SharedPtr node,
+    const controller_interface::ControllerInterface * controller_interface,
+    double action_monitor_rate, bool allow_partial_joints_goal,
+    std::vector<std::string> joint_names, bool allow_integration_in_goal_trajectories)
+  {
+    RCLCPP_INFO(LOGGER, "Action status changes will be monitored at %.2f Hz.", action_monitor_rate);
+    rclcpp::Duration action_monitor_period =
+      rclcpp::Duration::from_seconds(1.0 / action_monitor_rate);
+
+    //   using namespace std::placeholders;
+    action_server_ = rclcpp_action::create_server<FollowJTrajAction>(
+      node->get_node_base_interface(), node->get_node_clock_interface(),
+      node->get_node_logging_interface(), node->get_node_waitables_interface(),
+      std::string(node->get_name()) + "/follow_joint_trajectory",
+      std::bind(
+        &TrajectoryExecutionImpl::goal_callback, this, std::placeholders::_1, std::placeholders::_2,
+        controller_interface, allow_partial_joints_goal, joint_names,
+        allow_integration_in_goal_trajectories, node),
+      std::bind(&TrajectoryExecutionImpl::cancel_callback, this, std::placeholders::_1),
+      std::bind(
+        &TrajectoryExecutionImpl::feedback_setup_callback, this, std::placeholders::_1, node,
+        joint_names, action_monitor_period));
+  }
+
+  void fill_partial_goal(
+    std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg,
+    std::vector<std::string> joint_names,
+    std::vector<std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>>
+      joint_command_interface) const
+  {
+    // joint names in the goal are a subset of existing joints, as checked in goal_callback
+    // so if the size matches, the goal contains all controller joints
+    if (joint_names.size() == trajectory_msg->joint_names.size())
+    {
+      return;
+    }
+
+    trajectory_msg->joint_names.reserve(joint_names.size());
+
+    for (auto index = 0ul; index < joint_names.size(); ++index)
+    {
+      {
+        if (
+          std::find(
+            trajectory_msg->joint_names.begin(), trajectory_msg->joint_names.end(),
+            joint_names[index]) != trajectory_msg->joint_names.end())
+        {
+          // joint found on msg
+          continue;
+        }
+        trajectory_msg->joint_names.push_back(joint_names[index]);
+
+        for (auto & it : trajectory_msg->points)
+        {
+          // Assume hold position with 0 velocity and acceleration for missing joints
+          it.positions.push_back(joint_command_interface[0][index].get().get_value());
+          if (!it.velocities.empty())
+          {
+            it.velocities.push_back(0.0);
+          }
+          if (!it.accelerations.empty())
+          {
+            it.accelerations.push_back(0.0);
+          }
+          if (!it.effort.empty())
+          {
+            it.effort.push_back(0.0);
+          }
+        }
+      }
+    }
+  }
+
+  void sort_to_local_joint_order(
+    std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg,
+    std::vector<std::string> joint_names)
+  {
+    // rearrange all points in the trajectory message based on mapping
+    std::vector<size_t> mapping_vector = mapping(trajectory_msg->joint_names, joint_names);
+    auto remap = [this](
+                   const std::vector<double> & to_remap,
+                   const std::vector<size_t> & mapping) -> std::vector<double> {
+      if (to_remap.empty())
+      {
+        return to_remap;
+      }
+      if (to_remap.size() != mapping.size())
+      {
+        RCLCPP_WARN(LOGGER, "Invalid input size (%zu) for sorting", to_remap.size());
+        return to_remap;
+      }
+      std::vector<double> output;
+      output.resize(mapping.size(), 0.0);
+      for (auto index = 0ul; index < mapping.size(); ++index)
+      {
+        auto map_index = mapping[index];
+        output[map_index] = to_remap[index];
+      }
+      return output;
+    };
+
+    for (auto index = 0ul; index < trajectory_msg->points.size(); ++index)
+    {
+      trajectory_msg->points[index].positions =
+        remap(trajectory_msg->points[index].positions, mapping_vector);
+
+      trajectory_msg->points[index].velocities =
+        remap(trajectory_msg->points[index].velocities, mapping_vector);
+
+      trajectory_msg->points[index].accelerations =
+        remap(trajectory_msg->points[index].accelerations, mapping_vector);
+
+      trajectory_msg->points[index].effort =
+        remap(trajectory_msg->points[index].effort, mapping_vector);
+    }
+  }
+
+  bool validate_trajectory_point_field(
+    size_t joint_names_size, const std::vector<double> & vector_field,
+    const std::string & string_for_vector_field, size_t i, bool allow_empty) const
+  {
+    if (allow_empty && vector_field.empty())
+    {
+      return true;
+    }
+    if (joint_names_size != vector_field.size())
+    {
+      RCLCPP_ERROR(
+        LOGGER, "Mismatch between joint_names (%zu) and %s (%zu) at point #%zu.", joint_names_size,
+        string_for_vector_field.c_str(), vector_field.size(), i);
+      return false;
+    }
+    return true;
+  }
+
+  bool validate_trajectory_msg(
+    const trajectory_msgs::msg::JointTrajectory & trajectory, bool allow_partial_joints_goal,
+    std::vector<std::string> joint_names, bool allow_integration_in_goal_trajectories,
+    rclcpp::Time now) const
+  {
+    // If partial joints goals are not allowed, goal should specify all controller joints
+    if (!allow_partial_joints_goal)
+    {
+      if (trajectory.joint_names.size() != joint_names.size())
+      {
+        RCLCPP_ERROR(LOGGER, "Joints on incoming trajectory don't match the controller joints.");
+        return false;
+      }
+    }
+
+    if (trajectory.joint_names.empty())
+    {
+      RCLCPP_ERROR(LOGGER, "Empty joint names on incoming trajectory.");
+      return false;
+    }
+
+    const auto trajectory_start_time = static_cast<rclcpp::Time>(trajectory.header.stamp);
+    // If the starting time it set to 0.0, it means the controller should start it now.
+    // Otherwise we check if the trajectory ends before the current time,
+    // in which case it can be ignored.
+    if (trajectory_start_time.seconds() != 0.0)
+    {
+      auto trajectory_end_time = trajectory_start_time;
+      for (const auto & p : trajectory.points)
+      {
+        trajectory_end_time += p.time_from_start;
+      }
+      if (trajectory_end_time < now)
+      {
+        RCLCPP_ERROR(
+          LOGGER,
+          "Received trajectory with non zero time start time (%f) that ends on the past (%f)",
+          trajectory_start_time.seconds(), trajectory_end_time.seconds());
+        return false;
+      }
+    }
+
+    for (auto i = 0ul; i < trajectory.joint_names.size(); ++i)
+    {
+      const std::string & incoming_joint_name = trajectory.joint_names[i];
+
+      auto it = std::find(joint_names.begin(), joint_names.end(), incoming_joint_name);
+      if (it == joint_names.end())
+      {
+        RCLCPP_ERROR(
+          LOGGER, "Incoming joint %s doesn't match the controller's joints.",
+          incoming_joint_name.c_str());
+        return false;
+      }
+    }
+
+    rclcpp::Duration previous_traj_time(rclcpp::Duration::from_seconds(0));
+    for (auto i = 0ul; i < trajectory.points.size(); ++i)
+    {
+      if ((i > 0) && (rclcpp::Duration(trajectory.points[i].time_from_start) <= previous_traj_time))
+      {
+        RCLCPP_ERROR(
+          LOGGER,
+          "Time between points %zu and %zu is not strictly increasing, it is %f and %f "
+          "respectively",
+          i - 1, i, previous_traj_time.seconds(),
+          rclcpp::Duration(trajectory.points[i].time_from_start).seconds());
+        return false;
+      }
+      previous_traj_time = trajectory.points[i].time_from_start;
+
+      const size_t joint_count = trajectory.joint_names.size();
+      const auto & points = trajectory.points;
+      // TODO(anyone): This currently supports only position, velocity and acceleration inputs
+      if (allow_integration_in_goal_trajectories)
+      {
+        const bool all_empty = points[i].positions.empty() && points[i].velocities.empty() &&
+                               points[i].accelerations.empty();
+        const bool position_error =
+          !points[i].positions.empty() &&
+          !validate_trajectory_point_field(joint_count, points[i].positions, "positions", i, false);
+        const bool velocity_error = !points[i].velocities.empty() &&
+                                    !validate_trajectory_point_field(
+                                      joint_count, points[i].velocities, "velocities", i, false);
+        const bool acceleration_error =
+          !points[i].accelerations.empty() &&
+          !validate_trajectory_point_field(
+            joint_count, points[i].accelerations, "accelerations", i, false);
+        if (all_empty || position_error || velocity_error || acceleration_error)
+        {
+          return false;
+        }
+      }
+      else if (
+        !validate_trajectory_point_field(joint_count, points[i].positions, "positions", i, false) ||
+        !validate_trajectory_point_field(
+          joint_count, points[i].velocities, "velocities", i, true) ||
+        !validate_trajectory_point_field(
+          joint_count, points[i].accelerations, "accelerations", i, true) ||
+        // TODO(denis): should this be deleted, since effort goals are not supported?
+        !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void add_new_trajectory_msg(
+    const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & traj_msg)
+  {
+    traj_msg_external_point_ptr_.writeFromNonRT(traj_msg);
+  }
+
+  void preempt_active_goal()
+  {
+    const auto active_goal = *rt_active_goal_.readFromNonRT();
+    if (active_goal)
+    {
+      auto action_res = std::make_shared<FollowJTrajAction::Result>();
+      action_res->set__error_code(FollowJTrajAction::Result::INVALID_GOAL);
+      action_res->set__error_string("Current goal cancelled due to new incoming action.");
+      active_goal->setCanceled(action_res);
+      rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
+    }
+  }
+
+  void set_hold_position()
+  {
+    trajectory_msgs::msg::JointTrajectory empty_msg;
+    empty_msg.header.stamp = rclcpp::Time(0);
+
+    auto traj_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>(empty_msg);
+    add_new_trajectory_msg(traj_msg);
+  }
+
+  void resize_joint_trajectory_point(
+    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size,
+    bool has_velocity_state_interface, bool has_acceleration_state_interface)
+  {
+    point.positions.resize(size);
+    if (has_velocity_state_interface)
+    {
+      point.velocities.resize(size);
+    }
+    if (has_acceleration_state_interface)
+    {
+      point.accelerations.resize(size);
+    }
+  }
+
+  // TODO(karsten1987): eventually activate and deactivate subscriber directly when its supported
+  bool subscriber_is_active_ = false;
+  rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr joint_command_subscriber_ =
+    nullptr;
+
+  std::shared_ptr<Trajectory> * traj_point_active_ptr_ = nullptr;
+  std::shared_ptr<Trajectory> traj_external_point_ptr_ = nullptr;
+  std::shared_ptr<Trajectory> traj_home_point_ptr_ = nullptr;
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> traj_msg_home_ptr_ = nullptr;
+  realtime_tools::RealtimeBuffer<std::shared_ptr<trajectory_msgs::msg::JointTrajectory>>
+    traj_msg_external_point_ptr_;
+
+  rclcpp_action::Server<FollowJTrajAction>::SharedPtr action_server_;
+
+  RealtimeGoalHandleBuffer rt_active_goal_;  ///< Currently active action goal, if any.
+  rclcpp::TimerBase::SharedPtr goal_handle_timer_;
+};
+
+}  // namespace joint_trajectory_controller
+
+#endif  // JOINT_TRAJECTORY_CONTROLLER__TRAJECTORY_EXECUTION_IMPL_HPP_

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -137,19 +137,14 @@ controller_interface::return_type JointTrajectoryController::update()
   };
 
   // Check if a new external message has been received from nonRT threads
-  auto current_external_msg = traj_external_point_ptr_->get_trajectory_msg();
-  auto new_external_msg = traj_msg_external_point_ptr_.readFromRT();
-  if (current_external_msg != *new_external_msg)
-  {
-    fill_partial_goal(*new_external_msg);
-    sort_to_local_joint_order(*new_external_msg);
-    traj_external_point_ptr_->update(*new_external_msg);
-  }
+  check_for_new_trajectory(joint_names_, joint_command_interface_);
 
   JointTrajectoryPoint state_current, state_desired, state_error;
   const auto joint_num = joint_names_.size();
-  resize_joint_trajectory_point(state_current, joint_num);
-  resize_joint_trajectory_point(state_error, joint_num);
+  resize_joint_trajectory_point(
+    state_current, joint_num, has_velocity_state_interface_, has_acceleration_state_interface_);
+  resize_joint_trajectory_point(
+    state_error, joint_num, has_velocity_state_interface_, has_acceleration_state_interface_);
 
   // TODO(anyone): can I here also use const on joint_interface since the reference_wrapper is not
   // changed, but its value only?
@@ -166,33 +161,25 @@ controller_interface::return_type JointTrajectoryController::update()
   read_state_from_hardware(state_current);
 
   // currently carrying out a trajectory
-  if (traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_trajectory_msg())
+  if (have_trajectory())
   {
-    // if sampling the first time, set the point before you sample
-    if (!(*traj_point_active_ptr_)->is_sampled_already())
-    {
-      if (open_loop_control_)
-      {
-        (*traj_point_active_ptr_)
-          ->set_point_before_trajectory_msg(node_->now(), last_commanded_state_);
-      }
-      else
-      {
-        (*traj_point_active_ptr_)->set_point_before_trajectory_msg(node_->now(), state_current);
-      }
-    }
+    // if we will be sampling for the first time, prefix the trajectory with the current state
+    set_point_before_trajectory_msg(
+      open_loop_control_, node_->now(), state_current, last_commanded_state_);
 
     // find segment for current timestamp
     TrajectoryPointConstIter start_segment_itr, end_segment_itr;
-    const bool valid_point =
-      (*traj_point_active_ptr_)
-        ->sample(node_->now(), state_desired, start_segment_itr, end_segment_itr, joint_limiter_);
+
+    const bool valid_point = sample_trajectory(
+      node_->now(), state_desired, start_segment_itr, end_segment_itr, joint_limiter_);
 
     if (valid_point)
     {
       bool abort = false;
-      bool outside_goal_tolerance = false;
-      const bool before_last_point = end_segment_itr != (*traj_point_active_ptr_)->end();
+      bool outside_goal_state_tolerance = false;
+      // bool outside_goal_time_tolerance = false;
+      const bool before_last_point = is_before_last_point(end_segment_itr);
+      // const bool before_last_point = end_segment_itr != (*traj_point_active_ptr_)->end();
 
       // set values for next hardware write()
       if (has_position_command_interface_)
@@ -213,6 +200,7 @@ controller_interface::return_type JointTrajectoryController::update()
       //         assign_interface_from_point(joint_command_interface_[3], state_desired.effort);
       //       }
 
+      // check if we meet any conditions to abort trajectory execution for this controller
       for (auto index = 0ul; index < joint_num; ++index)
       {
         compute_error_for_joint(state_error, index, state_current, state_desired);
@@ -230,83 +218,33 @@ controller_interface::return_type JointTrajectoryController::update()
           !check_state_tolerance_per_joint(
             state_error, index, default_tolerances_.goal_state_tolerance[index], false))
         {
-          outside_goal_tolerance = true;
+          outside_goal_state_tolerance = true;
         }
       }
+      // TODO: Consider checking goal_time_tolerance tolerance here and passing it into perform_action_server_update
+      // if (!abort && !outside_goal_state_tolerance && !before_last_point && default_tolerances_.goal_time_tolerance != 0.0)
+      // {
+      //   // if we exceed goal_time_toleralance set it to aborted
+      //   const rclcpp::Time traj_start = (*traj_point_active_ptr_)->get_trajectory_start_time();
+      //   const rclcpp::Time traj_end = traj_start + start_segment_itr->time_from_start;
+
+      //   const double difference = node_->now().seconds() - traj_end.seconds();
+      //   if (difference > default_tolerances_.goal_time_tolerance)
+      //   {
+      //     outside_goal_time_tolerance = true;
+      //   }
+      // }
 
       // store command as state when hardware state has tracking offset
+      // TODO: Should we be checking if open_loop_control_ around this assignment?
       last_commanded_state_ = state_desired;
 
+      // handle action server feedback
+      perform_action_server_update(
+        before_last_point, abort, outside_goal_state_tolerance,
+        default_tolerances_.goal_time_tolerance, node_->now(), joint_names_, state_current,
+        state_desired, state_error, start_segment_itr);
       const auto active_goal = *rt_active_goal_.readFromRT();
-      if (active_goal)
-      {
-        // send feedback
-        auto feedback = std::make_shared<FollowJTrajAction::Feedback>();
-        feedback->header.stamp = node_->now();
-        feedback->joint_names = joint_names_;
-
-        feedback->actual = state_current;
-        feedback->desired = state_desired;
-        feedback->error = state_error;
-        active_goal->setFeedback(feedback);
-
-        // check abort
-        if (abort || outside_goal_tolerance)
-        {
-          auto result = std::make_shared<FollowJTrajAction::Result>();
-
-          if (abort)
-          {
-            RCLCPP_WARN(node_->get_logger(), "Aborted due to state tolerance violation");
-            result->set__error_code(FollowJTrajAction::Result::PATH_TOLERANCE_VIOLATED);
-          }
-          else if (outside_goal_tolerance)
-          {
-            RCLCPP_WARN(node_->get_logger(), "Aborted due to goal tolerance violation");
-            result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
-          }
-          active_goal->setAborted(result);
-          // TODO(matthew-reynolds): Need a lock-free write here
-          // See https://github.com/ros-controls/ros2_controllers/issues/168
-          rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-
-          // check goal tolerance
-        }
-        else if (!before_last_point)
-        {
-          if (!outside_goal_tolerance)
-          {
-            auto res = std::make_shared<FollowJTrajAction::Result>();
-            res->set__error_code(FollowJTrajAction::Result::SUCCESSFUL);
-            active_goal->setSucceeded(res);
-            // TODO(matthew-reynolds): Need a lock-free write here
-            // See https://github.com/ros-controls/ros2_controllers/issues/168
-            rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-
-            RCLCPP_INFO(node_->get_logger(), "Goal reached, success!");
-          }
-          else if (default_tolerances_.goal_time_tolerance != 0.0)
-          {
-            // if we exceed goal_time_toleralance set it to aborted
-            const rclcpp::Time traj_start = (*traj_point_active_ptr_)->get_trajectory_start_time();
-            const rclcpp::Time traj_end = traj_start + start_segment_itr->time_from_start;
-
-            const double difference = node_->now().seconds() - traj_end.seconds();
-            if (difference > default_tolerances_.goal_time_tolerance)
-            {
-              auto result = std::make_shared<FollowJTrajAction::Result>();
-              result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
-              active_goal->setAborted(result);
-              // TODO(matthew-reynolds): Need a lock-free write here
-              // See https://github.com/ros-controls/ros2_controllers/issues/168
-              rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-              RCLCPP_WARN(
-                node_->get_logger(), "Aborted due goal_time_tolerance exceeding by %f seconds",
-                difference);
-            }
-          }
-        }
-      }
     }
   }
   else
@@ -641,7 +579,9 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State &)
   // non realtime
   // TODO(karsten): check if traj msg and point time are valid
   auto callback = [this](const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> msg) -> void {
-    if (!validate_trajectory_msg(*msg))
+    if (!validate_trajectory_msg(
+          *msg, allow_partial_joints_goal_, joint_names_, allow_integration_in_goal_trajectories_,
+          node_->now()))
     {
       return;
     }
@@ -707,17 +647,9 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State &)
   const double action_monitor_rate =
     node_->get_parameter("action_monitor_rate").get_value<double>();
 
-  RCLCPP_INFO(logger, "Action status changes will be monitored at %.2f Hz.", action_monitor_rate);
-  action_monitor_period_ = rclcpp::Duration::from_seconds(1.0 / action_monitor_rate);
-
-  using namespace std::placeholders;
-  action_server_ = rclcpp_action::create_server<FollowJTrajAction>(
-    node_->get_node_base_interface(), node_->get_node_clock_interface(),
-    node_->get_node_logging_interface(), node_->get_node_waitables_interface(),
-    std::string(node_->get_name()) + "/follow_joint_trajectory",
-    std::bind(&JointTrajectoryController::goal_callback, this, _1, _2),
-    std::bind(&JointTrajectoryController::cancel_callback, this, _1),
-    std::bind(&JointTrajectoryController::feedback_setup_callback, this, _1));
+  create_action_server(
+    node_, this, action_monitor_rate, allow_partial_joints_goal_, joint_names_,
+    allow_integration_in_goal_trajectories_);
 
   RCLCPP_INFO(get_node()->get_logger(), "configure successful");
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
@@ -802,12 +734,15 @@ JointTrajectoryController::on_activate(const rclcpp_lifecycle::State &)
   last_state_publish_time_ = node_->now();
 
   // Initialize current state storage if hardware state has tracking offset
-  resize_joint_trajectory_point(last_commanded_state_, joint_names_.size());
+  resize_joint_trajectory_point(
+    last_commanded_state_, joint_names_.size(), has_velocity_state_interface_,
+    has_acceleration_state_interface_);
   read_state_from_hardware(last_commanded_state_);
   // Handle restart of controller by reading last_commanded_state_ from commands is
   // those are not nan
   trajectory_msgs::msg::JointTrajectoryPoint state;
-  resize_joint_trajectory_point(state, joint_names_.size());
+  resize_joint_trajectory_point(
+    state, joint_names_.size(), has_velocity_state_interface_, has_acceleration_state_interface_);
   if (read_state_from_command_interfaces(state))
   {
     last_commanded_state_ = state;
@@ -859,21 +794,6 @@ JointTrajectoryController::on_error(const rclcpp_lifecycle::State &)
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-bool JointTrajectoryController::reset()
-{
-  subscriber_is_active_ = false;
-  joint_command_subscriber_.reset();
-
-  // iterator has no default value
-  // prev_traj_point_ptr_;
-  traj_point_active_ptr_ = nullptr;
-  traj_external_point_ptr_.reset();
-  traj_home_point_ptr_.reset();
-  traj_msg_home_ptr_.reset();
-
-  return true;
-}
-
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 JointTrajectoryController::on_shutdown(const rclcpp_lifecycle::State &)
 {
@@ -920,337 +840,11 @@ void JointTrajectoryController::publish_state(
   }
 }
 
-rclcpp_action::GoalResponse JointTrajectoryController::goal_callback(
-  const rclcpp_action::GoalUUID &, std::shared_ptr<const FollowJTrajAction::Goal> goal)
-{
-  RCLCPP_INFO(node_->get_logger(), "Received new action goal");
-
-  // Precondition: Running controller
-  if (get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-  {
-    RCLCPP_ERROR(node_->get_logger(), "Can't accept new action goals. Controller is not running.");
-    return rclcpp_action::GoalResponse::REJECT;
-  }
-
-  if (!validate_trajectory_msg(goal->trajectory))
-  {
-    return rclcpp_action::GoalResponse::REJECT;
-  }
-
-  // TODO(denis): is here the following line missing?
-  //   add_new_trajectory_msg(std::make_shared(goal->trajectory));
-
-  RCLCPP_INFO(node_->get_logger(), "Accepted new action goal");
-  return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
-}
-
-rclcpp_action::CancelResponse JointTrajectoryController::cancel_callback(
-  const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle)
-{
-  RCLCPP_INFO(node_->get_logger(), "Got request to cancel goal");
-
-  // Check that cancel request refers to currently active goal (if any)
-  const auto active_goal = *rt_active_goal_.readFromNonRT();
-  if (active_goal && active_goal->gh_ == goal_handle)
-  {
-    // Controller uptime
-    // Enter hold current position mode
-    set_hold_position();
-
-    RCLCPP_DEBUG(
-      node_->get_logger(), "Canceling active action goal because cancel callback received.");
-
-    // Mark the current goal as canceled
-    auto action_res = std::make_shared<FollowJTrajAction::Result>();
-    active_goal->setCanceled(action_res);
-    rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-  }
-  return rclcpp_action::CancelResponse::ACCEPT;
-}
-
-void JointTrajectoryController::feedback_setup_callback(
-  std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle)
-{
-  // Update new trajectory
-  {
-    preempt_active_goal();
-    auto traj_msg =
-      std::make_shared<trajectory_msgs::msg::JointTrajectory>(goal_handle->get_goal()->trajectory);
-
-    add_new_trajectory_msg(traj_msg);
-  }
-
-  // Update the active goal
-  RealtimeGoalHandlePtr rt_goal = std::make_shared<RealtimeGoalHandle>(goal_handle);
-  rt_goal->preallocated_feedback_->joint_names = joint_names_;
-  rt_goal->execute();
-  rt_active_goal_.writeFromNonRT(rt_goal);
-
-  // Setup goal status checking timer
-  goal_handle_timer_ = node_->create_wall_timer(
-    action_monitor_period_.to_chrono<std::chrono::seconds>(),
-    std::bind(&RealtimeGoalHandle::runNonRealtime, rt_goal));
-}
-
-void JointTrajectoryController::fill_partial_goal(
-  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg) const
-{
-  // joint names in the goal are a subset of existing joints, as checked in goal_callback
-  // so if the size matches, the goal contains all controller joints
-  if (joint_names_.size() == trajectory_msg->joint_names.size())
-  {
-    return;
-  }
-
-  trajectory_msg->joint_names.reserve(joint_names_.size());
-
-  for (auto index = 0ul; index < joint_names_.size(); ++index)
-  {
-    {
-      if (
-        std::find(
-          trajectory_msg->joint_names.begin(), trajectory_msg->joint_names.end(),
-          joint_names_[index]) != trajectory_msg->joint_names.end())
-      {
-        // joint found on msg
-        continue;
-      }
-      trajectory_msg->joint_names.push_back(joint_names_[index]);
-
-      for (auto & it : trajectory_msg->points)
-      {
-        // Assume hold position with 0 velocity and acceleration for missing joints
-        it.positions.push_back(joint_command_interface_[0][index].get().get_value());
-        if (!it.velocities.empty())
-        {
-          it.velocities.push_back(0.0);
-        }
-        if (!it.accelerations.empty())
-        {
-          it.accelerations.push_back(0.0);
-        }
-        if (!it.effort.empty())
-        {
-          it.effort.push_back(0.0);
-        }
-      }
-    }
-  }
-}
-
-void JointTrajectoryController::sort_to_local_joint_order(
-  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg)
-{
-  // rearrange all points in the trajectory message based on mapping
-  std::vector<size_t> mapping_vector = mapping(trajectory_msg->joint_names, joint_names_);
-  auto remap = [this](
-                 const std::vector<double> & to_remap,
-                 const std::vector<size_t> & mapping) -> std::vector<double> {
-    if (to_remap.empty())
-    {
-      return to_remap;
-    }
-    if (to_remap.size() != mapping.size())
-    {
-      RCLCPP_WARN(node_->get_logger(), "Invalid input size (%zu) for sorting", to_remap.size());
-      return to_remap;
-    }
-    std::vector<double> output;
-    output.resize(mapping.size(), 0.0);
-    for (auto index = 0ul; index < mapping.size(); ++index)
-    {
-      auto map_index = mapping[index];
-      output[map_index] = to_remap[index];
-    }
-    return output;
-  };
-
-  for (auto index = 0ul; index < trajectory_msg->points.size(); ++index)
-  {
-    trajectory_msg->points[index].positions =
-      remap(trajectory_msg->points[index].positions, mapping_vector);
-
-    trajectory_msg->points[index].velocities =
-      remap(trajectory_msg->points[index].velocities, mapping_vector);
-
-    trajectory_msg->points[index].accelerations =
-      remap(trajectory_msg->points[index].accelerations, mapping_vector);
-
-    trajectory_msg->points[index].effort =
-      remap(trajectory_msg->points[index].effort, mapping_vector);
-  }
-}
-
-bool JointTrajectoryController::validate_trajectory_point_field(
-  size_t joint_names_size, const std::vector<double> & vector_field,
-  const std::string & string_for_vector_field, size_t i, bool allow_empty) const
-{
-  if (allow_empty && vector_field.empty())
-  {
-    return true;
-  }
-  if (joint_names_size != vector_field.size())
-  {
-    RCLCPP_ERROR(
-      node_->get_logger(), "Mismatch between joint_names (%zu) and %s (%zu) at point #%zu.",
-      joint_names_size, string_for_vector_field.c_str(), vector_field.size(), i);
-    return false;
-  }
-  return true;
-}
-
-bool JointTrajectoryController::validate_trajectory_msg(
-  const trajectory_msgs::msg::JointTrajectory & trajectory) const
-{
-  // If partial joints goals are not allowed, goal should specify all controller joints
-  if (!allow_partial_joints_goal_)
-  {
-    if (trajectory.joint_names.size() != joint_names_.size())
-    {
-      RCLCPP_ERROR(
-        node_->get_logger(), "Joints on incoming trajectory don't match the controller joints.");
-      return false;
-    }
-  }
-
-  if (trajectory.joint_names.empty())
-  {
-    RCLCPP_ERROR(node_->get_logger(), "Empty joint names on incoming trajectory.");
-    return false;
-  }
-
-  const auto trajectory_start_time = static_cast<rclcpp::Time>(trajectory.header.stamp);
-  // If the starting time it set to 0.0, it means the controller should start it now.
-  // Otherwise we check if the trajectory ends before the current time,
-  // in which case it can be ignored.
-  if (trajectory_start_time.seconds() != 0.0)
-  {
-    auto trajectory_end_time = trajectory_start_time;
-    for (const auto & p : trajectory.points)
-    {
-      trajectory_end_time += p.time_from_start;
-    }
-    if (trajectory_end_time < node_->now())
-    {
-      RCLCPP_ERROR(
-        node_->get_logger(),
-        "Received trajectory with non zero time start time (%f) that ends on the past (%f)",
-        trajectory_start_time.seconds(), trajectory_end_time.seconds());
-      return false;
-    }
-  }
-
-  for (auto i = 0ul; i < trajectory.joint_names.size(); ++i)
-  {
-    const std::string & incoming_joint_name = trajectory.joint_names[i];
-
-    auto it = std::find(joint_names_.begin(), joint_names_.end(), incoming_joint_name);
-    if (it == joint_names_.end())
-    {
-      RCLCPP_ERROR(
-        node_->get_logger(), "Incoming joint %s doesn't match the controller's joints.",
-        incoming_joint_name.c_str());
-      return false;
-    }
-  }
-
-  rclcpp::Duration previous_traj_time(rclcpp::Duration::from_seconds(0));
-  for (auto i = 0ul; i < trajectory.points.size(); ++i)
-  {
-    if ((i > 0) && (rclcpp::Duration(trajectory.points[i].time_from_start) <= previous_traj_time))
-    {
-      RCLCPP_ERROR(
-        node_->get_logger(),
-        "Time between points %zu and %zu is not strictly increasing, it is %f and %f respectively",
-        i - 1, i, previous_traj_time.seconds(),
-        rclcpp::Duration(trajectory.points[i].time_from_start).seconds());
-      return false;
-    }
-    previous_traj_time = trajectory.points[i].time_from_start;
-
-    const size_t joint_count = trajectory.joint_names.size();
-    const auto & points = trajectory.points;
-    // TODO(anyone): This currently supports only position, velocity and acceleration inputs
-    if (allow_integration_in_goal_trajectories_)
-    {
-      const bool all_empty = points[i].positions.empty() && points[i].velocities.empty() &&
-                             points[i].accelerations.empty();
-      const bool position_error =
-        !points[i].positions.empty() &&
-        !validate_trajectory_point_field(joint_count, points[i].positions, "positions", i, false);
-      const bool velocity_error =
-        !points[i].velocities.empty() &&
-        !validate_trajectory_point_field(joint_count, points[i].velocities, "velocities", i, false);
-      const bool acceleration_error =
-        !points[i].accelerations.empty() &&
-        !validate_trajectory_point_field(
-          joint_count, points[i].accelerations, "accelerations", i, false);
-      if (all_empty || position_error || velocity_error || acceleration_error)
-      {
-        return false;
-      }
-    }
-    else if (
-      !validate_trajectory_point_field(joint_count, points[i].positions, "positions", i, false) ||
-      !validate_trajectory_point_field(joint_count, points[i].velocities, "velocities", i, true) ||
-      !validate_trajectory_point_field(
-        joint_count, points[i].accelerations, "accelerations", i, true) ||
-      // TODO(denis): should this be deleted, since effort goals are not supported?
-      !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true))
-    {
-      return false;
-    }
-  }
-  return true;
-}
-
-void JointTrajectoryController::add_new_trajectory_msg(
-  const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & traj_msg)
-{
-  traj_msg_external_point_ptr_.writeFromNonRT(traj_msg);
-}
-
-void JointTrajectoryController::preempt_active_goal()
-{
-  const auto active_goal = *rt_active_goal_.readFromNonRT();
-  if (active_goal)
-  {
-    auto action_res = std::make_shared<FollowJTrajAction::Result>();
-    action_res->set__error_code(FollowJTrajAction::Result::INVALID_GOAL);
-    action_res->set__error_string("Current goal cancelled due to new incoming action.");
-    active_goal->setCanceled(action_res);
-    rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-  }
-}
-
-void JointTrajectoryController::set_hold_position()
-{
-  trajectory_msgs::msg::JointTrajectory empty_msg;
-  empty_msg.header.stamp = rclcpp::Time(0);
-
-  auto traj_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>(empty_msg);
-  add_new_trajectory_msg(traj_msg);
-}
-
 bool JointTrajectoryController::contains_interface_type(
   const std::vector<std::string> & interface_type_list, const std::string & interface_type)
 {
   return std::find(interface_type_list.begin(), interface_type_list.end(), interface_type) !=
          interface_type_list.end();
-}
-
-void JointTrajectoryController::resize_joint_trajectory_point(
-  trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size)
-{
-  point.positions.resize(size);
-  if (has_velocity_state_interface_)
-  {
-    point.velocities.resize(size);
-  }
-  if (has_acceleration_state_interface_)
-  {
-    point.accelerations.resize(size);
-  }
 }
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1,1294 +1,1294 @@
-// Copyright 2017 Open Source Robotics Foundation, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// // Copyright 2017 Open Source Robotics Foundation, Inc.
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
 
-#include <stddef.h>
+// #include <stddef.h>
 
-#include <array>
-#include <chrono>
-#include <future>
-#include <limits>
-#include <memory>
-#include <stdexcept>
-#include <string>
-#include <system_error>
-#include <thread>
-#include <vector>
+// #include <array>
+// #include <chrono>
+// #include <future>
+// #include <limits>
+// #include <memory>
+// #include <stdexcept>
+// #include <string>
+// #include <system_error>
+// #include <thread>
+// #include <vector>
 
-#include "gtest/gtest.h"
+// #include "gtest/gtest.h"
 
-#include "builtin_interfaces/msg/duration.hpp"
-#include "builtin_interfaces/msg/time.hpp"
-#include "control_msgs/msg/detail/joint_trajectory_controller_state__struct.hpp"
-#include "controller_interface/controller_interface.hpp"
-#include "hardware_interface/resource_manager.hpp"
-#include "joint_trajectory_controller/joint_trajectory_controller.hpp"
-#include "lifecycle_msgs/msg/state.hpp"
-#include "rclcpp/clock.hpp"
-#include "rclcpp/duration.hpp"
-#include "rclcpp/executors/multi_threaded_executor.hpp"
-#include "rclcpp/executors/single_threaded_executor.hpp"
-#include "rclcpp/node.hpp"
-#include "rclcpp/parameter.hpp"
-#include "rclcpp/publisher.hpp"
-#include "rclcpp/qos.hpp"
-#include "rclcpp/qos_event.hpp"
-#include "rclcpp/subscription.hpp"
-#include "rclcpp/time.hpp"
-#include "rclcpp/utilities.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
-#include "rclcpp_lifecycle/state.hpp"
-#include "std_msgs/msg/header.hpp"
-#include "test_trajectory_controller_utils.hpp"
-#include "trajectory_msgs/msg/joint_trajectory.hpp"
-#include "trajectory_msgs/msg/joint_trajectory_point.hpp"
+// #include "builtin_interfaces/msg/duration.hpp"
+// #include "builtin_interfaces/msg/time.hpp"
+// #include "control_msgs/msg/detail/joint_trajectory_controller_state__struct.hpp"
+// #include "controller_interface/controller_interface.hpp"
+// #include "hardware_interface/resource_manager.hpp"
+// #include "joint_trajectory_controller/joint_trajectory_controller.hpp"
+// #include "lifecycle_msgs/msg/state.hpp"
+// #include "rclcpp/clock.hpp"
+// #include "rclcpp/duration.hpp"
+// #include "rclcpp/executors/multi_threaded_executor.hpp"
+// #include "rclcpp/executors/single_threaded_executor.hpp"
+// #include "rclcpp/node.hpp"
+// #include "rclcpp/parameter.hpp"
+// #include "rclcpp/publisher.hpp"
+// #include "rclcpp/qos.hpp"
+// #include "rclcpp/qos_event.hpp"
+// #include "rclcpp/subscription.hpp"
+// #include "rclcpp/time.hpp"
+// #include "rclcpp/utilities.hpp"
+// #include "rclcpp_lifecycle/lifecycle_node.hpp"
+// #include "rclcpp_lifecycle/state.hpp"
+// #include "std_msgs/msg/header.hpp"
+// #include "test_trajectory_controller_utils.hpp"
+// #include "trajectory_msgs/msg/joint_trajectory.hpp"
+// #include "trajectory_msgs/msg/joint_trajectory_point.hpp"
 
-using lifecycle_msgs::msg::State;
-using test_trajectory_controllers::TestableJointTrajectoryController;
-using test_trajectory_controllers::TrajectoryControllerTest;
-using test_trajectory_controllers::TrajectoryControllerTestParameterized;
+// using lifecycle_msgs::msg::State;
+// using test_trajectory_controllers::TestableJointTrajectoryController;
+// using test_trajectory_controllers::TrajectoryControllerTest;
+// using test_trajectory_controllers::TrajectoryControllerTestParameterized;
 
-void spin(rclcpp::executors::MultiThreadedExecutor * exe) { exe->spin(); }
+// void spin(rclcpp::executors::MultiThreadedExecutor * exe) { exe->spin(); }
 
-TEST_P(TrajectoryControllerTestParameterized, configure)
-{
-  SetUpTrajectoryController();
+// TEST_P(TrajectoryControllerTestParameterized, configure)
+// {
+//   SetUpTrajectoryController();
 
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(traj_controller_->get_node()->get_node_base_interface());
-  const auto future_handle_ = std::async(std::launch::async, spin, &executor);
-
-  const auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-
-  // send msg
-  builtin_interfaces::msg::Duration time_from_start;
-  time_from_start.sec = 1;
-  time_from_start.nanosec = 0;
-  std::vector<std::vector<double>> points{{{3.3, 4.4, 5.5}}};
-  publish(time_from_start, points);
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
-  traj_controller_->update();
-
-  // hw position == 0 because controller is not activated
-  EXPECT_EQ(0.0, joint_pos_[0]);
-  EXPECT_EQ(0.0, joint_pos_[1]);
-  EXPECT_EQ(0.0, joint_pos_[2]);
-
-  executor.cancel();
-}
-
-TEST_P(TrajectoryControllerTestParameterized, activate)
-{
-  SetUpTrajectoryController();
-
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(traj_controller_->get_node()->get_node_base_interface());
-
-  traj_controller_->configure();
-  ASSERT_EQ(traj_controller_->get_state().id(), State::PRIMARY_STATE_INACTIVE);
-
-  auto cmd_interface_config = traj_controller_->command_interface_configuration();
-  ASSERT_EQ(
-    cmd_interface_config.names.size(), joint_names_.size() * command_interface_types_.size());
-
-  auto state_interface_config = traj_controller_->state_interface_configuration();
-  ASSERT_EQ(
-    state_interface_config.names.size(), joint_names_.size() * state_interface_types_.size());
-
-  ActivateTrajectoryController();
-  ASSERT_EQ(traj_controller_->get_state().id(), State::PRIMARY_STATE_ACTIVE);
-
-  executor.cancel();
-}
-
-// TEST_F(TestTrajectoryController, activation) {
-//   auto traj_controller = std::make_shared<ros_controllers::JointTrajectoryController>(
-//     joint_names_, op_mode_);
-//   auto ret = traj_controller->init(test_robot_, controller_name_);
-//   if (ret != controller_interface::return_type::OK) {
-//     FAIL();
-//   }
-//
-//   auto traj_node = traj_controller->get_node();
 //   rclcpp::executors::MultiThreadedExecutor executor;
-//   executor.add_node(traj_node->get_node_base_interface());
-//
-//   auto state = traj_controller_->configure();
+//   executor.add_node(traj_controller_->get_node()->get_node_base_interface());
+//   const auto future_handle_ = std::async(std::launch::async, spin, &executor);
+
+//   const auto state = traj_controller_->configure();
 //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-//
-//   state = traj_node->activate();
-//   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
-//
-//   // wait for the subscriber and publisher to completely setup
-//   std::this_thread::sleep_for(std::chrono::seconds(2));
-//
+
 //   // send msg
 //   builtin_interfaces::msg::Duration time_from_start;
 //   time_from_start.sec = 1;
 //   time_from_start.nanosec = 0;
-//   std::vector<std::vector<double>> points {{{3.3, 4.4, 5.5}}};
+//   std::vector<std::vector<double>> points{{{3.3, 4.4, 5.5}}};
 //   publish(time_from_start, points);
-//   // wait for msg is be published to the system
-//   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-//   executor.spin_once();
-//
-//   traj_controller->update();
-//   resource_manager_->write();
-//
-//   // change in hw position
-//   EXPECT_EQ(3.3, joint_pos_[0]);
-//   EXPECT_EQ(4.4, joint_pos_[1]);
-//   EXPECT_EQ(5.5, joint_pos_[2]);
-//
+//   std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+//   traj_controller_->update();
+
+//   // hw position == 0 because controller is not activated
+//   EXPECT_EQ(0.0, joint_pos_[0]);
+//   EXPECT_EQ(0.0, joint_pos_[1]);
+//   EXPECT_EQ(0.0, joint_pos_[2]);
+
 //   executor.cancel();
 // }
 
-// TEST_F(TestTrajectoryController, reactivation) {
-//   auto traj_controller = std::make_shared<ros_controllers::JointTrajectoryController>(
-//     joint_names_, op_mode_);
-//   auto ret = traj_controller->init(test_robot_, controller_name_);
-//   if (ret != controller_interface::return_type::OK) {
-//     FAIL();
-//   }
-//
-//   auto traj_node = traj_controller->get_node();
+// TEST_P(TrajectoryControllerTestParameterized, activate)
+// {
+//   SetUpTrajectoryController();
+
+//   rclcpp::executors::MultiThreadedExecutor executor;
+//   executor.add_node(traj_controller_->get_node()->get_node_base_interface());
+
+//   traj_controller_->configure();
+//   ASSERT_EQ(traj_controller_->get_state().id(), State::PRIMARY_STATE_INACTIVE);
+
+//   auto cmd_interface_config = traj_controller_->command_interface_configuration();
+//   ASSERT_EQ(
+//     cmd_interface_config.names.size(), joint_names_.size() * command_interface_types_.size());
+
+//   auto state_interface_config = traj_controller_->state_interface_configuration();
+//   ASSERT_EQ(
+//     state_interface_config.names.size(), joint_names_.size() * state_interface_types_.size());
+
+//   ActivateTrajectoryController();
+//   ASSERT_EQ(traj_controller_->get_state().id(), State::PRIMARY_STATE_ACTIVE);
+
+//   executor.cancel();
+// }
+
+// // TEST_F(TestTrajectoryController, activation) {
+// //   auto traj_controller = std::make_shared<ros_controllers::JointTrajectoryController>(
+// //     joint_names_, op_mode_);
+// //   auto ret = traj_controller->init(test_robot_, controller_name_);
+// //   if (ret != controller_interface::return_type::OK) {
+// //     FAIL();
+// //   }
+// //
+// //   auto traj_node = traj_controller->get_node();
+// //   rclcpp::executors::MultiThreadedExecutor executor;
+// //   executor.add_node(traj_node->get_node_base_interface());
+// //
+// //   auto state = traj_controller_->configure();
+// //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+// //
+// //   state = traj_node->activate();
+// //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
+// //
+// //   // wait for the subscriber and publisher to completely setup
+// //   std::this_thread::sleep_for(std::chrono::seconds(2));
+// //
+// //   // send msg
+// //   builtin_interfaces::msg::Duration time_from_start;
+// //   time_from_start.sec = 1;
+// //   time_from_start.nanosec = 0;
+// //   std::vector<std::vector<double>> points {{{3.3, 4.4, 5.5}}};
+// //   publish(time_from_start, points);
+// //   // wait for msg is be published to the system
+// //   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+// //   executor.spin_once();
+// //
+// //   traj_controller->update();
+// //   resource_manager_->write();
+// //
+// //   // change in hw position
+// //   EXPECT_EQ(3.3, joint_pos_[0]);
+// //   EXPECT_EQ(4.4, joint_pos_[1]);
+// //   EXPECT_EQ(5.5, joint_pos_[2]);
+// //
+// //   executor.cancel();
+// // }
+
+// // TEST_F(TestTrajectoryController, reactivation) {
+// //   auto traj_controller = std::make_shared<ros_controllers::JointTrajectoryController>(
+// //     joint_names_, op_mode_);
+// //   auto ret = traj_controller->init(test_robot_, controller_name_);
+// //   if (ret != controller_interface::return_type::OK) {
+// //     FAIL();
+// //   }
+// //
+// //   auto traj_node = traj_controller->get_node();
+// //   rclcpp::executors::MultiThreadedExecutor executor;
+// //   executor.add_node(traj_node->get_node_base_interface());
+// //
+// //   auto state = traj_controller_->configure();
+// //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+// //
+// //   state = traj_node->activate();
+// //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
+// //
+// //   // wait for the subscriber and publisher to completely setup
+// //   std::this_thread::sleep_for(std::chrono::seconds(2));
+// //
+// //   // send msg
+// //   builtin_interfaces::msg::Duration time_from_start;
+// //   time_from_start.sec = 1;
+// //   time_from_start.nanosec = 0;
+// //   // *INDENT-OFF*
+// //   std::vector<std::vector<double>> points {
+// //     {{3.3, 4.4, 5.5}},
+// //     {{7.7, 8.8, 9.9}},
+// //     {{10.10, 11.11, 12.12}}
+// //   };
+// //   // *INDENT-ON*
+// //   publish(time_from_start, points);
+// //   // wait for msg is be published to the system
+// //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
+// //   executor.spin_once();
+// //
+// //   traj_controller->update();
+// //   resource_manager_->write();
+// //
+// //   // deactivated
+// //   // wait so controller process the second point when deactivated
+// //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
+// //   state = traj_controller_->deactivate();
+// //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+// //   resource_manager_->read();
+// //   traj_controller->update();
+// //   resource_manager_->write();
+// //
+// //   // no change in hw position
+// //   EXPECT_EQ(3.3, joint_pos_[0]);
+// //   EXPECT_EQ(4.4, joint_pos_[1]);
+// //   EXPECT_EQ(5.5, joint_pos_[2]);
+// //
+// //   // reactivated
+// //   // wait so controller process the third point when reactivated
+// //   std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+// //   state = traj_node->activate();
+// //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
+// //   resource_manager_->read();
+// //   traj_controller->update();
+// //   resource_manager_->write();
+// //
+// //   // change in hw position to 3rd point
+// //   EXPECT_EQ(10.10, joint_pos_[0]);
+// //   EXPECT_EQ(11.11, joint_pos_[1]);
+// //   EXPECT_EQ(12.12, joint_pos_[2]);
+// //
+// //   executor.cancel();
+// // }
+
+// TEST_P(TrajectoryControllerTestParameterized, cleanup)
+// {
+//   SetUpAndActivateTrajectoryController();
+
+//   auto traj_node = traj_controller_->get_node();
 //   rclcpp::executors::MultiThreadedExecutor executor;
 //   executor.add_node(traj_node->get_node_base_interface());
-//
-//   auto state = traj_controller_->configure();
-//   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-//
-//   state = traj_node->activate();
-//   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
-//
-//   // wait for the subscriber and publisher to completely setup
-//   std::this_thread::sleep_for(std::chrono::seconds(2));
-//
+
 //   // send msg
 //   builtin_interfaces::msg::Duration time_from_start;
 //   time_from_start.sec = 1;
 //   time_from_start.nanosec = 0;
+//   std::vector<std::vector<double>> points{{{3.3, 4.4, 5.5}}};
+//   publish(time_from_start, points);
+//   traj_controller_->wait_for_trajectory(executor);
+//   traj_controller_->update();
+
+//   auto state = traj_controller_->deactivate();
+//   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+//   traj_controller_->update();
+
+//   state = traj_controller_->cleanup();
+//   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+//   // update for 0.25 seconds
+//   const auto start_time = rclcpp::Clock().now();
+//   updateController(rclcpp::Duration::from_seconds(0.25));
+
+//   // should be home pose again
+//   EXPECT_NEAR(INITIAL_POS_JOINT1, joint_pos_[0], COMMON_THRESHOLD);
+//   EXPECT_NEAR(INITIAL_POS_JOINT2, joint_pos_[1], COMMON_THRESHOLD);
+//   EXPECT_NEAR(INITIAL_POS_JOINT3, joint_pos_[2], COMMON_THRESHOLD);
+
+//   executor.cancel();
+// }
+
+// TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_parameters)
+// {
+//   SetUpTrajectoryController(false);
+
+//   SetParameters();  // This call is replacing the way parameters are set via launch
+//   traj_controller_->configure();
+//   auto state = traj_controller_->get_state();
+//   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+
+//   ActivateTrajectoryController();
+//   rclcpp::executors::MultiThreadedExecutor executor;
+//   executor.add_node(traj_controller_->get_node()->get_node_base_interface());
+
+//   state = traj_controller_->get_state();
+//   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+//   EXPECT_EQ(INITIAL_POS_JOINT1, joint_pos_[0]);
+//   EXPECT_EQ(INITIAL_POS_JOINT2, joint_pos_[1]);
+//   EXPECT_EQ(INITIAL_POS_JOINT3, joint_pos_[2]);
+
+//   // send msg
+//   constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(250);
+//   builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(FIRST_POINT_TIME)};
 //   // *INDENT-OFF*
-//   std::vector<std::vector<double>> points {
-//     {{3.3, 4.4, 5.5}},
-//     {{7.7, 8.8, 9.9}},
-//     {{10.10, 11.11, 12.12}}
-//   };
+//   std::vector<std::vector<double>> points{
+//     {{3.3, 4.4, 5.5}}, {{7.7, 8.8, 9.9}}, {{10.10, 11.11, 12.12}}};
 //   // *INDENT-ON*
 //   publish(time_from_start, points);
-//   // wait for msg is be published to the system
-//   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-//   executor.spin_once();
-//
-//   traj_controller->update();
-//   resource_manager_->write();
-//
-//   // deactivated
+//   traj_controller_->wait_for_trajectory(executor);
+
+//   // first update
+//   traj_controller_->update();
+
 //   // wait so controller process the second point when deactivated
-//   std::this_thread::sleep_for(std::chrono::milliseconds(500));
+//   std::this_thread::sleep_for(FIRST_POINT_TIME);
+//   traj_controller_->update();
+//   // deactivated
 //   state = traj_controller_->deactivate();
 //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-//   resource_manager_->read();
-//   traj_controller->update();
-//   resource_manager_->write();
-//
-//   // no change in hw position
-//   EXPECT_EQ(3.3, joint_pos_[0]);
-//   EXPECT_EQ(4.4, joint_pos_[1]);
-//   EXPECT_EQ(5.5, joint_pos_[2]);
-//
-//   // reactivated
-//   // wait so controller process the third point when reactivated
-//   std::this_thread::sleep_for(std::chrono::milliseconds(3000));
-//   state = traj_node->activate();
-//   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
-//   resource_manager_->read();
-//   traj_controller->update();
-//   resource_manager_->write();
-//
-//   // change in hw position to 3rd point
-//   EXPECT_EQ(10.10, joint_pos_[0]);
-//   EXPECT_EQ(11.11, joint_pos_[1]);
-//   EXPECT_EQ(12.12, joint_pos_[2]);
-//
+
+//   // TODO(denis): on my laptop I get delta of approx 0.1083. Is this me or is it something wrong?
+//   // Come the flackiness here?
+//   const auto allowed_delta = 0.11;  // 0.05;
+
+//   EXPECT_NEAR(3.3, joint_pos_[0], allowed_delta);
+//   EXPECT_NEAR(4.4, joint_pos_[1], allowed_delta);
+//   EXPECT_NEAR(5.5, joint_pos_[2], allowed_delta);
+
+//   // cleanup
+//   state = traj_controller_->cleanup();
+
+//   // update loop receives a new msg and updates accordingly
+//   traj_controller_->update();
+
+//   // check the traj_msg_home_ptr_ initialization code for the standard wait timing
+//   std::this_thread::sleep_for(std::chrono::milliseconds(50));
+//   traj_controller_->update();
+//   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+
+//   EXPECT_NEAR(INITIAL_POS_JOINT1, joint_pos_[0], allowed_delta);
+//   EXPECT_NEAR(INITIAL_POS_JOINT2, joint_pos_[1], allowed_delta);
+//   EXPECT_NEAR(INITIAL_POS_JOINT3, joint_pos_[2], allowed_delta);
+
+//   state = traj_controller_->configure();
+//   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+
 //   executor.cancel();
 // }
 
-TEST_P(TrajectoryControllerTestParameterized, cleanup)
-{
-  SetUpAndActivateTrajectoryController();
-
-  auto traj_node = traj_controller_->get_node();
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(traj_node->get_node_base_interface());
-
-  // send msg
-  builtin_interfaces::msg::Duration time_from_start;
-  time_from_start.sec = 1;
-  time_from_start.nanosec = 0;
-  std::vector<std::vector<double>> points{{{3.3, 4.4, 5.5}}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
-  traj_controller_->update();
-
-  auto state = traj_controller_->deactivate();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
-  traj_controller_->update();
-
-  state = traj_controller_->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
-  // update for 0.25 seconds
-  const auto start_time = rclcpp::Clock().now();
-  updateController(rclcpp::Duration::from_seconds(0.25));
-
-  // should be home pose again
-  EXPECT_NEAR(INITIAL_POS_JOINT1, joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_NEAR(INITIAL_POS_JOINT2, joint_pos_[1], COMMON_THRESHOLD);
-  EXPECT_NEAR(INITIAL_POS_JOINT3, joint_pos_[2], COMMON_THRESHOLD);
-
-  executor.cancel();
-}
-
-TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_parameters)
-{
-  SetUpTrajectoryController(false);
-
-  SetParameters();  // This call is replacing the way parameters are set via launch
-  traj_controller_->configure();
-  auto state = traj_controller_->get_state();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
-
-  ActivateTrajectoryController();
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(traj_controller_->get_node()->get_node_base_interface());
-
-  state = traj_controller_->get_state();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
-  EXPECT_EQ(INITIAL_POS_JOINT1, joint_pos_[0]);
-  EXPECT_EQ(INITIAL_POS_JOINT2, joint_pos_[1]);
-  EXPECT_EQ(INITIAL_POS_JOINT3, joint_pos_[2]);
-
-  // send msg
-  constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(250);
-  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(FIRST_POINT_TIME)};
-  // *INDENT-OFF*
-  std::vector<std::vector<double>> points{
-    {{3.3, 4.4, 5.5}}, {{7.7, 8.8, 9.9}}, {{10.10, 11.11, 12.12}}};
-  // *INDENT-ON*
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
-
-  // first update
-  traj_controller_->update();
-
-  // wait so controller process the second point when deactivated
-  std::this_thread::sleep_for(FIRST_POINT_TIME);
-  traj_controller_->update();
-  // deactivated
-  state = traj_controller_->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-
-  // TODO(denis): on my laptop I get delta of approx 0.1083. Is this me or is it something wrong?
-  // Come the flackiness here?
-  const auto allowed_delta = 0.11;  // 0.05;
-
-  EXPECT_NEAR(3.3, joint_pos_[0], allowed_delta);
-  EXPECT_NEAR(4.4, joint_pos_[1], allowed_delta);
-  EXPECT_NEAR(5.5, joint_pos_[2], allowed_delta);
-
-  // cleanup
-  state = traj_controller_->cleanup();
-
-  // update loop receives a new msg and updates accordingly
-  traj_controller_->update();
-
-  // check the traj_msg_home_ptr_ initialization code for the standard wait timing
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  traj_controller_->update();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
-
-  EXPECT_NEAR(INITIAL_POS_JOINT1, joint_pos_[0], allowed_delta);
-  EXPECT_NEAR(INITIAL_POS_JOINT2, joint_pos_[1], allowed_delta);
-  EXPECT_NEAR(INITIAL_POS_JOINT3, joint_pos_[2], allowed_delta);
-
-  state = traj_controller_->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
-
-  executor.cancel();
-}
-
-TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {}, &executor);
-  subscribeToState();
-  updateController();
-
-  // Spin to receive latest state
-  executor.spin_some();
-  auto state = getState();
-
-  size_t n_joints = joint_names_.size();
-
-  for (unsigned int i = 0; i < n_joints; ++i)
-  {
-    EXPECT_EQ(joint_names_[i], state->joint_names[i]);
-  }
-
-  // No trajectory by default, no desired state or error
-  EXPECT_TRUE(state->desired.positions.empty());
-  EXPECT_TRUE(state->desired.velocities.empty());
-  EXPECT_TRUE(state->desired.accelerations.empty());
-
-  EXPECT_EQ(n_joints, state->actual.positions.size());
-  if (
-    std::find(state_interface_types_.begin(), state_interface_types_.end(), "velocity") ==
-    state_interface_types_.end())
-  {
-    EXPECT_TRUE(state->actual.velocities.empty());
-  }
-  else
-  {
-    EXPECT_EQ(n_joints, state->actual.velocities.size());
-  }
-  if (
-    std::find(state_interface_types_.begin(), state_interface_types_.end(), "acceleration") ==
-    state_interface_types_.end())
-  {
-    EXPECT_TRUE(state->actual.accelerations.empty());
-  }
-  else
-  {
-    EXPECT_EQ(n_joints, state->actual.accelerations.size());
-  }
-
-  EXPECT_TRUE(state->error.positions.empty());
-  EXPECT_TRUE(state->error.velocities.empty());
-  EXPECT_TRUE(state->error.accelerations.empty());
-}
-
-void TrajectoryControllerTest::test_state_publish_rate_target(int target_msg_count)
-{
-  rclcpp::Parameter state_publish_rate_param(
-    "state_publish_rate", static_cast<double>(target_msg_count));
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {state_publish_rate_param}, &executor);
-
-  auto future_handle = std::async(std::launch::async, [&executor]() -> void { executor.spin(); });
-
-  using control_msgs::msg::JointTrajectoryControllerState;
-
-  const int qos_level = 10;
-  int echo_received_counter = 0;
-  rclcpp::Subscription<JointTrajectoryControllerState>::SharedPtr subs =
-    traj_node_->create_subscription<JointTrajectoryControllerState>(
-      controller_name_ + "/state", qos_level,
-      [&](JointTrajectoryControllerState::UniquePtr) { ++echo_received_counter; });
-
-  // update for 1second
-  const auto start_time = rclcpp::Clock().now();
-  const rclcpp::Duration wait = rclcpp::Duration::from_seconds(1.0);
-  const auto end_time = start_time + wait;
-  while (rclcpp::Clock().now() < end_time)
-  {
-    traj_controller_->update();
-  }
-
-  // We may miss the last message since time allowed is exactly the time needed
-  EXPECT_NEAR(target_msg_count, echo_received_counter, 1);
-
-  executor.cancel();
-}
-
-/**
- * @brief test_state_publish_rate Test that state publish rate matches configure rate
- */
-TEST_P(TrajectoryControllerTestParameterized, test_state_publish_rate)
-{
-  test_state_publish_rate_target(10);
-}
-
-TEST_P(TrajectoryControllerTestParameterized, zero_state_publish_rate)
-{
-  test_state_publish_rate_target(0);
-}
-
-TEST_P(TrajectoryControllerTestParameterized, zero_state_publish_rate1)
-{
-  test_state_publish_rate_target(0);
-}
-
-TEST_P(TrajectoryControllerTestParameterized, test_states_values_are_properly_initialized)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {}, &executor);
-
-  auto future_handle = std::async(
-    std::launch::async, [&executor]() -> void {
-      executor.spin();
-    });
-
-  using control_msgs::msg::JointTrajectoryControllerState;
-
-  auto callback = [this](const JointTrajectoryControllerState::UniquePtr state) -> void
-  {
-    ASSERT_TRUE(!state->joint_names.empty());
-    ASSERT_EQ(state->joint_names.size(), joint_names_.size());
-    ASSERT_TRUE(std::equal(state->joint_names.begin(), state->joint_names.end(),
-                           joint_names_.begin(), joint_names_.end()));
-
-    auto check_state_field = [&](const auto & field) -> void
-    {
-      ASSERT_EQ(field.size(), joint_names_.size());
-      for (auto i = 0ul; i < field.size(); ++i) {
-        ASSERT_FALSE(std::isnan(field[i]));
-      }
-    };
-
-    check_state_field(state->desired.positions);
-    check_state_field(state->desired.velocities);
-    check_state_field(state->desired.accelerations);
-
-    check_state_field(state->actual.positions);
-    check_state_field(state->error.positions);
-
-    // check velocity
-    if (std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end())
-    {
-      check_state_field(state->actual.velocities);
-      check_state_field(state->error.velocities);
-    }
-
-    // check acceleration
-    if (std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end())
-    {
-      check_state_field(state->actual.accelerations);
-      check_state_field(state->error.accelerations);
-    }
-  };
-
-  const int qos_level = 10;
-  rclcpp::Subscription<JointTrajectoryControllerState>::SharedPtr subs =
-    traj_node_->create_subscription<JointTrajectoryControllerState>(
-    controller_name_ + "/state", qos_level, callback);
-
-  executor.cancel();
-}
-
-/**
- * @brief test_jumbled_joint_order Test sending trajectories with a joint order different from internal controller order
- */
-TEST_P(TrajectoryControllerTestParameterized, test_jumbled_joint_order)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {}, &executor);
-  {
-    trajectory_msgs::msg::JointTrajectory traj_msg;
-    const std::vector<std::string> jumbled_joint_names{
-      joint_names_[1], joint_names_[2], joint_names_[0]};
-    traj_msg.joint_names = jumbled_joint_names;
-    traj_msg.header.stamp = rclcpp::Time(0);
-    traj_msg.points.resize(1);
-
-    traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
-    traj_msg.points[0].positions.resize(3);
-    traj_msg.points[0].positions[0] = 2.0;
-    traj_msg.points[0].positions[1] = 3.0;
-    traj_msg.points[0].positions[2] = 1.0;
-
-    trajectory_publisher_->publish(traj_msg);
-  }
-
-  traj_controller_->wait_for_trajectory(executor);
-  // update for 0.25 seconds
-  // TODO(destogl): Make this time a bit shorter to increase stability on the CI?
-  //                Currently COMMON_THRESHOLD is adjusted.
-  updateController(rclcpp::Duration::from_seconds(0.25));
-
-  EXPECT_NEAR(1.0, joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_NEAR(2.0, joint_pos_[1], COMMON_THRESHOLD);
-  EXPECT_NEAR(3.0, joint_pos_[2], COMMON_THRESHOLD);
-}
-
-/**
- * @brief test_partial_joint_list Test sending trajectories with a subset of the controlled joints
- */
-TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list)
-{
-  rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
-
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {partial_joints_parameters}, &executor);
-
-  const double initial_joint3_cmd = joint_pos_[2];
-  trajectory_msgs::msg::JointTrajectory traj_msg;
-
-  {
-    std::vector<std::string> partial_joint_names{joint_names_[1], joint_names_[0]};
-    traj_msg.joint_names = partial_joint_names;
-    traj_msg.header.stamp = rclcpp::Time(0);
-    traj_msg.points.resize(1);
-
-    traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
-    traj_msg.points[0].positions.resize(2);
-    traj_msg.points[0].positions[0] = 2.0;
-    traj_msg.points[0].positions[1] = 1.0;
-    traj_msg.points[0].velocities.resize(2);
-    traj_msg.points[0].velocities[0] = 2.0;
-    traj_msg.points[0].velocities[1] = 1.0;
-
-    trajectory_publisher_->publish(traj_msg);
-  }
-
-  traj_controller_->wait_for_trajectory(executor);
-  // update for 0.5 seconds
-  updateController(rclcpp::Duration::from_seconds(0.25));
-
-  double threshold = 0.001;
-  EXPECT_NEAR(traj_msg.points[0].positions[1], joint_pos_[0], threshold);
-  EXPECT_NEAR(traj_msg.points[0].positions[0], joint_pos_[1], threshold);
-  EXPECT_NEAR(initial_joint3_cmd, joint_pos_[2], threshold)
-    << "Joint 3 command should be current position";
-
-  if (
-    std::find(command_interface_types_.begin(), command_interface_types_.end(), "velocity") !=
-    command_interface_types_.end())
-  {
-    // TODO(anyone): need help here - we should at least estimate the sign of the velocity
-    //     EXPECT_NEAR(traj_msg.points[0].velocities[1], joint_vel_[0], threshold);
-    //     EXPECT_NEAR(traj_msg.points[0].velocities[0], joint_vel_[1], threshold);
-    EXPECT_NEAR(0.0, joint_vel_[2], threshold)
-      << "Joint 3 velocity should be 0.0 since it's not in the goal";
-  }
-  // TODO(anyone): add here ckecks for acceleration commands
-
-  executor.cancel();
-}
-
-/**
- * @brief test_partial_joint_list Test sending trajectories with a subset of the controlled joints without allow_partial_joints_goal
- */
-TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list_not_allowed)
-{
-  rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", false);
-
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {partial_joints_parameters}, &executor);
-
-  const double initial_joint1_cmd = joint_pos_[0];
-  const double initial_joint2_cmd = joint_pos_[1];
-  const double initial_joint3_cmd = joint_pos_[2];
-  const double initial_joint_vel = 0.0;
-  const double initial_joint_acc = 0.0;
-  trajectory_msgs::msg::JointTrajectory traj_msg;
-
-  {
-    std::vector<std::string> partial_joint_names{joint_names_[1], joint_names_[0]};
-    traj_msg.joint_names = partial_joint_names;
-    traj_msg.header.stamp = rclcpp::Time(0);
-    traj_msg.points.resize(1);
-
-    traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
-    traj_msg.points[0].positions.resize(2);
-    traj_msg.points[0].positions[0] = 2.0;
-    traj_msg.points[0].positions[1] = 1.0;
-    traj_msg.points[0].velocities.resize(2);
-    traj_msg.points[0].velocities[0] = 2.0;
-    traj_msg.points[0].velocities[1] = 1.0;
-
-    trajectory_publisher_->publish(traj_msg);
-  }
-
-  traj_controller_->wait_for_trajectory(executor);
-  // update for 0.5 seconds
-  updateController(rclcpp::Duration::from_seconds(0.25));
-
-  double threshold = 0.001;
-  EXPECT_NEAR(initial_joint1_cmd, joint_pos_[0], threshold)
-    << "All joints command should be current position because goal was rejected";
-  EXPECT_NEAR(initial_joint2_cmd, joint_pos_[1], threshold)
-    << "All joints command should be current position because goal was rejected";
-  EXPECT_NEAR(initial_joint3_cmd, joint_pos_[2], threshold)
-    << "All joints command should be current position because goal was rejected";
-
-  if (
-    std::find(command_interface_types_.begin(), command_interface_types_.end(), "velocity") !=
-    command_interface_types_.end())
-  {
-    EXPECT_NEAR(initial_joint_vel, joint_vel_[0], threshold)
-      << "All joints velocities should be 0.0 because goal was rejected";
-    EXPECT_NEAR(initial_joint_vel, joint_vel_[1], threshold)
-      << "All joints velocities should be 0.0 because goal was rejected";
-    EXPECT_NEAR(initial_joint_vel, joint_vel_[2], threshold)
-      << "All joints velocities should be 0.0 because goal was rejected";
-  }
-
-  if (
-    std::find(command_interface_types_.begin(), command_interface_types_.end(), "acceleration") !=
-    command_interface_types_.end())
-  {
-    EXPECT_NEAR(initial_joint_acc, joint_acc_[0], threshold)
-      << "All joints accelerations should be 0.0 because goal was rejected";
-    EXPECT_NEAR(initial_joint_acc, joint_acc_[1], threshold)
-      << "All joints accelerations should be 0.0 because goal was rejected";
-    EXPECT_NEAR(initial_joint_acc, joint_acc_[2], threshold)
-      << "All joints accelerations should be 0.0 because goal was rejected";
-  }
-
-  executor.cancel();
-}
-
-/**
- * @brief invalid_message Test mismatched joint and reference vector sizes
- */
-TEST_P(TrajectoryControllerTestParameterized, invalid_message)
-{
-  rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", false);
-  rclcpp::Parameter allow_integration_parameters("allow_integration_in_goal_trajectories", false);
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(
-    true, {partial_joints_parameters, allow_integration_parameters}, &executor);
-
-  trajectory_msgs::msg::JointTrajectory traj_msg, good_traj_msg;
-
-  good_traj_msg.joint_names = joint_names_;
-  good_traj_msg.header.stamp = rclcpp::Time(0);
-  good_traj_msg.points.resize(1);
-  good_traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
-  good_traj_msg.points[0].positions.resize(1);
-  good_traj_msg.points[0].positions = {1.0, 2.0, 3.0};
-  good_traj_msg.points[0].velocities.resize(1);
-  good_traj_msg.points[0].velocities = {-1.0, -2.0, -3.0};
-  EXPECT_TRUE(traj_controller_->validate_trajectory_msg(good_traj_msg));
-
-  // Incompatible joint names
-  traj_msg = good_traj_msg;
-  traj_msg.joint_names = {"bad_name"};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // No position data
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].positions.clear();
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Incompatible data sizes, too few positions
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].positions = {1.0, 2.0};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Incompatible data sizes, too many positions
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].positions = {1.0, 2.0, 3.0, 4.0};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Incompatible data sizes, too few velocities
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].velocities = {1.0, 2.0};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Incompatible data sizes, too few accelerations
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].accelerations = {1.0, 2.0};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Incompatible data sizes, too few efforts
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].positions.clear();
-  traj_msg.points[0].effort = {1.0, 2.0};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Non-strictly increasing waypoint times
-  traj_msg = good_traj_msg;
-  traj_msg.points.push_back(traj_msg.points.front());
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-}
-
-/// With allow_integration_in_goal_trajectories parameter trajectory missing position or velocities
-/// are accepted
-TEST_P(TrajectoryControllerTestParameterized, missing_positions_message_accepted)
-{
-  rclcpp::Parameter allow_integration_parameters("allow_integration_in_goal_trajectories", true);
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {allow_integration_parameters}, &executor);
-
-  trajectory_msgs::msg::JointTrajectory traj_msg, good_traj_msg;
-
-  good_traj_msg.joint_names = joint_names_;
-  good_traj_msg.header.stamp = rclcpp::Time(0);
-  good_traj_msg.points.resize(1);
-  good_traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
-  good_traj_msg.points[0].positions.resize(1);
-  good_traj_msg.points[0].positions = {1.0, 2.0, 3.0};
-  good_traj_msg.points[0].velocities.resize(1);
-  good_traj_msg.points[0].velocities = {-1.0, -2.0, -3.0};
-  good_traj_msg.points[0].accelerations.resize(1);
-  good_traj_msg.points[0].accelerations = {1.0, 2.0, 3.0};
-  EXPECT_TRUE(traj_controller_->validate_trajectory_msg(good_traj_msg));
-
-  // No position data
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].positions.clear();
-  EXPECT_TRUE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // No position and velocity data
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].positions.clear();
-  traj_msg.points[0].velocities.clear();
-  EXPECT_TRUE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // All empty
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].positions.clear();
-  traj_msg.points[0].velocities.clear();
-  traj_msg.points[0].accelerations.clear();
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Incompatible data sizes, too few positions
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].positions = {1.0, 2.0};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Incompatible data sizes, too many positions
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].positions = {1.0, 2.0, 3.0, 4.0};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Incompatible data sizes, too few velocities
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].velocities = {1.0};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-
-  // Incompatible data sizes, too few accelerations
-  traj_msg = good_traj_msg;
-  traj_msg.points[0].accelerations = {2.0};
-  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
-}
-
-/**
- * @brief test_trajectory_replace Test replacing an existing trajectory
- */
-TEST_P(TrajectoryControllerTestParameterized, test_trajectory_replace)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
-  SetUpAndActivateTrajectoryController(true, {partial_joints_parameters}, &executor);
-
-  subscribeToState();
-
-  std::vector<std::vector<double>> points_old{{{2., 3., 4.}}};
-  std::vector<std::vector<double>> points_partial_new{{1.5}};
-
-  const auto delay = std::chrono::milliseconds(500);
-  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(delay)};
-  publish(time_from_start, points_old);
-  trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
-  expected_actual.positions = {points_old[0].begin(), points_old[0].end()};
-  expected_desired.positions = {points_old[0].begin(), points_old[0].end()};
-  //  Check that we reached end of points_old trajectory
-  // Denis: delta was 0.1 with 0.2 works for me
-  waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.2);
-
-  RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory");
-  publish(time_from_start, points_partial_new);
-  // Replaced trajectory is a mix of previous and current goal
-  expected_desired.positions[0] = points_partial_new[0][0];
-  expected_desired.positions[1] = points_old[0][1];
-  expected_desired.positions[2] = points_old[0][2];
-  expected_actual = expected_desired;
-  waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
-}
-
-/**
- * @brief test_ignore_old_trajectory Sending an old trajectory replacing an existing trajectory
- */
-TEST_P(TrajectoryControllerTestParameterized, test_ignore_old_trajectory)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {}, &executor);
-  subscribeToState();
-
-  // TODO(anyone): add expectations for velocities and accelerations
-  std::vector<std::vector<double>> points_old{{{2., 3., 4.}, {4., 5., 6.}}};
-  std::vector<std::vector<double>> points_new{{{-1., -2., -3.}}};
-
-  const auto delay = std::chrono::milliseconds(500);
-  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(delay)};
-  publish(time_from_start, points_old);
-  trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
-  expected_actual.positions = {points_old[0].begin(), points_old[0].end()};
-  expected_desired = expected_actual;
-  //  Check that we reached end of points_old[0] trajectory
-  waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
-
-  RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory in the past");
-  //  New trajectory will end before current time
-  rclcpp::Time new_traj_start = rclcpp::Clock().now() - delay - std::chrono::milliseconds(100);
-  expected_actual.positions = {points_old[1].begin(), points_old[1].end()};
-  expected_desired = expected_actual;
-  publish(time_from_start, points_new, new_traj_start);
-  waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
-}
-
-TEST_P(TrajectoryControllerTestParameterized, test_ignore_partial_old_trajectory)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {}, &executor);
-  subscribeToState();
-
-  std::vector<std::vector<double>> points_old{{{2., 3., 4.}, {4., 5., 6.}}};
-  std::vector<std::vector<double>> points_new{{{-1., -2., -3.}, {-2., -4., -6.}}};
-
-  const auto delay = std::chrono::milliseconds(500);
-  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(delay)};
-  publish(time_from_start, points_old);
-  trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
-  expected_actual.positions = {points_old[0].begin(), points_old[0].end()};
-  expected_desired = expected_actual;
-  //  Check that we reached end of points_old[0]trajectory
-  waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
-
-  RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory partially in the past");
-  //  New trajectory first point is in the past, second is in the future
-  rclcpp::Time new_traj_start = rclcpp::Clock().now() - delay - std::chrono::milliseconds(100);
-  expected_actual.positions = {points_new[1].begin(), points_new[1].end()};
-  expected_desired = expected_actual;
-  publish(time_from_start, points_new, new_traj_start);
-  waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
-}
-
-TEST_P(TrajectoryControllerTestParameterized, test_execute_partial_traj_in_future)
-{
-  SetUpTrajectoryController();
-  auto traj_node = traj_controller_->get_node();
-  RCLCPP_WARN(
-    traj_node->get_logger(),
-    "Test disabled until current_trajectory is taken into account when adding a new trajectory.");
-  // https://github.com/ros-controls/ros_controllers/blob/melodic-devel/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h#L149
-  return;
-
-  // TODO(anyone): use SetUpAndActivateTrajectoryController method instead of the next line
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(traj_node->get_node_base_interface());
-  subscribeToState();
-  rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
-  traj_node->set_parameter(partial_joints_parameters);
-  traj_controller_->configure();
-  traj_controller_->activate();
-
-  std::vector<std::vector<double>> full_traj{{{2., 3., 4.}, {4., 6., 8.}}};
-  std::vector<std::vector<double>> partial_traj{
-    {{-1., -2.},
-     {
-       -2.,
-       -4,
-     }}};
-  const auto delay = std::chrono::milliseconds(500);
-  builtin_interfaces::msg::Duration points_delay{rclcpp::Duration(delay)};
-  // Send full trajectory
-  publish(points_delay, full_traj);
-  // Sleep until first waypoint of full trajectory
-
-  trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
-  expected_actual.positions = {full_traj[0].begin(), full_traj[0].end()};
-  expected_desired = expected_actual;
-  //  Check that we reached end of points_old[0]trajectory and are starting points_old[1]
-  waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
-
-  // Send partial trajectory starting after full trajecotry is complete
-  RCLCPP_INFO(traj_node->get_logger(), "Sending new trajectory in the future");
-  publish(points_delay, partial_traj, rclcpp::Clock().now() + delay * 2);
-  // Wait until the end start and end of partial traj
-
-  expected_actual.positions = {partial_traj.back()[0], partial_traj.back()[1], full_traj.back()[2]};
-  expected_desired = expected_actual;
-
-  waitAndCompareState(
-    expected_actual, expected_desired, executor, rclcpp::Duration(delay * (2 + 2)), 0.1);
-}
-
-TEST_P(TrajectoryControllerTestParameterized, test_jump_when_state_tracking_error_updated)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  // default if false so it will not be actually set parameter
-  rclcpp::Parameter is_open_loop_parameters("open_loop_control", false);
-  SetUpAndActivateTrajectoryController(true, {is_open_loop_parameters}, &executor, true);
-
-  // goal setup
-  std::vector<double> first_goal = {3.3, 4.4, 5.5};
-  std::vector<double> second_goal = {6.6, 8.8, 11.0};
-  double state_from_command_offset = 0.3;
-
-  // send msg
-  builtin_interfaces::msg::Duration time_from_start;
-  time_from_start.sec = 1;
-  time_from_start.nanosec = 0;
-  std::vector<std::vector<double>> points{{first_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
-  updateController(rclcpp::Duration::from_seconds(1.1));
-
-  // JTC is executing trajectory in open-loop therefore:
-  // - internal state does not have to be updated (in this test-case it shouldn't)
-  // - internal command is updated
-  EXPECT_NEAR(INITIAL_POS_JOINT1, joint_state_pos_[0], COMMON_THRESHOLD);
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-
-  // State interface should have offset from the command before starting a new trajectory
-  joint_state_pos_[0] = first_goal[0] - state_from_command_offset;
-
-  // Move joint further in the same direction as before (to the second goal)
-  points = {{second_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
-
-  // One the first update(s) there should be a "jump" in opposite direction from command
-  // (towards the state value)
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  traj_controller_->update();
-  // Expect backward commands at first
-  EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_LT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update();
-  EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_LT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update();
-  EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_LT(joint_pos_[0], first_goal[0]);
-
-  // Finally the second goal will be commanded/reached
-  updateController(rclcpp::Duration::from_seconds(1.1));
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-
-  // State interface should have offset from the command before starting a new trajectory
-  joint_state_pos_[0] = second_goal[0] - state_from_command_offset;
-
-  // Move joint back to the first goal
-  points = {{first_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
-
-  // One the first update(s) there should be a "jump" in the goal direction from command
-  // (towards the state value)
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  traj_controller_->update();
-  // Expect backward commands at first
-  EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update();
-  EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update();
-  EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-
-  // Finally the first goal will be commanded/reached
-  updateController(rclcpp::Duration::from_seconds(1.1));
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-
-  executor.cancel();
-}
-
-TEST_P(
-  TrajectoryControllerTestParameterized, test_no_jump_when_state_tracking_error_not_updated)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  // default if false so it will not be actually set paramter
-  rclcpp::Parameter is_open_loop_parameters("open_loop_control", true);
-  SetUpAndActivateTrajectoryController(true, {is_open_loop_parameters}, &executor, true);
-
-  // goal setup
-  std::vector<double> first_goal = {3.3, 4.4, 5.5};
-  std::vector<double> second_goal = {6.6, 8.8, 11.0};
-  double state_from_command_offset = 0.3;
-
-  // send msg
-  builtin_interfaces::msg::Duration time_from_start;
-  time_from_start.sec = 1;
-  time_from_start.nanosec = 0;
-  std::vector<std::vector<double>> points {{first_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
-  updateController(rclcpp::Duration::from_seconds(1.1));
-
-  // JTC is executing trajectory in open-loop therefore:
-  // - internal state does not have to be updated (in this test-case it shouldn't)
-  // - internal command is updated
-  EXPECT_NEAR(INITIAL_POS_JOINT1, joint_state_pos_[0], COMMON_THRESHOLD);
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-
-  // State interface should have offset from the command before starting a new trajectory
-  joint_state_pos_[0] = first_goal[0] - state_from_command_offset;
-
-  // Move joint further in the same direction as before (to the second goal)
-  points = {{second_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
-
-  // One the first update(s) there **should not** be a "jump" in opposite direction from command
-  // (towards the state value)
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  traj_controller_->update();
-  // There should not be backward commands
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-  traj_controller_->update();
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-  traj_controller_->update();
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-
-  // Finally the second goal will be commanded/reached
-  updateController(rclcpp::Duration::from_seconds(1.1));
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-
-  // State interface should have offset from the command before starting a new trajectory
-  joint_state_pos_[0] = second_goal[0] - state_from_command_offset;
-
-  // Move joint back to the first goal
-  points = {{first_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
-
-  // One the first update(s) there **should not** be a "jump" in the goal direction from command
-  // (towards the state value)
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  traj_controller_->update();
-  // There should not be a jump toward commands
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update();
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-  traj_controller_->update();
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-
-  // Finally the first goal will be commanded/reached
-  updateController(rclcpp::Duration::from_seconds(1.1));
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-
-  executor.cancel();
-}
-
-// Testing that values are read from state interfaces when hardware is started for the first
-// time and hardware state has offset --> this is indicated by NaN values in state interfaces
-TEST_P(
-  TrajectoryControllerTestParameterized, test_hw_states_has_offset_first_controller_start)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  // default if false so it will not be actually set paramter
-  rclcpp::Parameter is_open_loop_parameters("open_loop_control", true);
-
-  // set command values to NaN
-  for (auto i = 0u; i < 3; ++i) {
-    joint_pos_[i] = std::numeric_limits<double>::quiet_NaN();
-    joint_vel_[i] = std::numeric_limits<double>::quiet_NaN();
-    joint_acc_[i] = std::numeric_limits<double>::quiet_NaN();
-  }
-  SetUpAndActivateTrajectoryController(true, {is_open_loop_parameters}, &executor, true);
-
-  auto current_state_when_offset = traj_controller_->get_current_state_when_offset();
-
-  for (auto i = 0u; i < 3; ++i) {
-    EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
-
-    // check velocity
-    if (std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end() &&
-      std::find(
-        command_interface_types_.begin(), command_interface_types_.end(),
-        hardware_interface::HW_IF_VELOCITY) != command_interface_types_.end())
-    {
-      EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
-    }
-
-    // check acceleration
-    if (std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end() &&
-      std::find(
-        command_interface_types_.begin(), command_interface_types_.end(),
-        hardware_interface::HW_IF_ACCELERATION) != command_interface_types_.end())
-    {
-      EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
-    }
-  }
-
-  executor.cancel();
-}
-
-// Testing that values are read from state interfaces when hardware is started after some values
-// are set on the hardware commands
-TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_controller_start)
-{
-  rclcpp::executors::SingleThreadedExecutor executor;
-  // default if false so it will not be actually set parameter
-  rclcpp::Parameter is_open_loop_parameters("open_loop_control", true);
-
-  // set command values to NaN
-  for (auto i = 0u; i < 3; ++i)
-  {
-    joint_pos_[i] = 3.1 + i;
-    joint_vel_[i] = 0.25 + i;
-    joint_acc_[i] = 0.02 + i / 10.0;
-  }
-  SetUpAndActivateTrajectoryController(true, {is_open_loop_parameters}, &executor, true);
-
-  auto current_state_when_offset = traj_controller_->get_current_state_when_offset();
-
-  for (auto i = 0u; i < 3; ++i)
-  {
-    EXPECT_EQ(current_state_when_offset.positions[i], joint_pos_[i]);
-
-    // check velocity
-    if (
-      std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end() &&
-      std::find(
-        command_interface_types_.begin(), command_interface_types_.end(),
-        hardware_interface::HW_IF_VELOCITY) != command_interface_types_.end())
-    {
-      EXPECT_EQ(current_state_when_offset.positions[i], joint_pos_[i]);
-    }
-
-    // check acceleration
-    if (
-      std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end() &&
-      std::find(
-        command_interface_types_.begin(), command_interface_types_.end(),
-        hardware_interface::HW_IF_ACCELERATION) != command_interface_types_.end())
-    {
-      EXPECT_EQ(current_state_when_offset.positions[i], joint_pos_[i]);
-    }
-  }
-
-  executor.cancel();
-}
-
-// position controllers
-INSTANTIATE_TEST_SUITE_P(
-  PositionTrajectoryControllers,
-  TrajectoryControllerTestParameterized,
-  ::testing::Values(
-    std::make_tuple(std::vector<std::string>({"position"}), std::vector<std::string>({"position"})),
-    std::make_tuple(
-      std::vector<std::string>({"position"}), std::vector<std::string>({"position", "velocity"})),
-    std::make_tuple(
-      std::vector<std::string>({"position"}),
-      std::vector<std::string>({"position", "velocity", "acceleration"}))));
-
-// position_velocity controllers
-INSTANTIATE_TEST_SUITE_P(
-  PositionVelocityTrajectoryControllers,
-  TrajectoryControllerTestParameterized,
-  ::testing::Values(
-    std::make_tuple(
-      std::vector<std::string>({"position", "velocity"}), std::vector<std::string>({"position"})),
-    std::make_tuple(
-      std::vector<std::string>({"position", "velocity"}),
-      std::vector<std::string>({"position", "velocity"})),
-    std::make_tuple(
-      std::vector<std::string>({"position", "velocity"}),
-      std::vector<std::string>({"position", "velocity", "acceleration"}))));
-
-// position_velocity_acceleration controllers
-INSTANTIATE_TEST_SUITE_P(
-  PositionVelocityAccelerationTrajectoryControllers,
-  TrajectoryControllerTestParameterized,
-  ::testing::Values(
-    std::make_tuple(
-      std::vector<std::string>({"position", "velocity", "acceleration"}),
-      std::vector<std::string>({"position"})),
-    std::make_tuple(
-      std::vector<std::string>({"position", "velocity", "acceleration"}),
-      std::vector<std::string>({"position", "velocity"})),
-    std::make_tuple(
-      std::vector<std::string>({"position", "velocity", "acceleration"}),
-      std::vector<std::string>({"position", "velocity", "acceleration"}))));
-
-TEST_F(TrajectoryControllerTest, incorrect_initialization_using_interface_parameters)
-{
-  auto set_parameter_and_check_result = [&]() {
-    EXPECT_EQ(traj_controller_->get_state().id(), State::PRIMARY_STATE_UNCONFIGURED);
-    SetParameters();  // This call is replacing the way parameters are set via launch
-    traj_controller_->configure();
-    EXPECT_EQ(traj_controller_->get_state().id(), State::PRIMARY_STATE_UNCONFIGURED);
-  };
-
-  SetUpTrajectoryController(false);
-
-  // command interfaces: empty
-  command_interface_types_ = {};
-  set_parameter_and_check_result();
-
-  // command interfaces: bad_name
-  command_interface_types_ = {"bad_name"};
-  set_parameter_and_check_result();
-
-  // command interfaces: effort not yet implemented
-  command_interface_types_ = {"effort"};
-  set_parameter_and_check_result();
-
-  // command interfaces: effort has to be only
-  command_interface_types_ = {"effort", "position"};
-  set_parameter_and_check_result();
-
-  // command interfaces: velocity alone not yet implemented
-  command_interface_types_ = {"velocity"};
-  set_parameter_and_check_result();
-
-  // command interfaces: velocity - position not present
-  command_interface_types_ = {"velocity", "acceleration"};
-  set_parameter_and_check_result();
-
-  // command interfaces: acceleration without position and velocity
-  command_interface_types_ = {"acceleration"};
-  set_parameter_and_check_result();
-
-  // state interfaces: empty
-  state_interface_types_ = {};
-  set_parameter_and_check_result();
-
-  // state interfaces: cannot not be effort
-  state_interface_types_ = {"effort"};
-  set_parameter_and_check_result();
-
-  // state interfaces: bad name
-  state_interface_types_ = {"bad_name"};
-  set_parameter_and_check_result();
-
-  // state interfaces: velocity - position not present
-  state_interface_types_ = {"velocity"};
-  set_parameter_and_check_result();
-  state_interface_types_ = {"velocity", "acceleration"};
-  set_parameter_and_check_result();
-
-  // state interfaces: acceleration without position and velocity
-  state_interface_types_ = {"acceleration"};
-  set_parameter_and_check_result();
-}
+// TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(true, {}, &executor);
+//   subscribeToState();
+//   updateController();
+
+//   // Spin to receive latest state
+//   executor.spin_some();
+//   auto state = getState();
+
+//   size_t n_joints = joint_names_.size();
+
+//   for (unsigned int i = 0; i < n_joints; ++i)
+//   {
+//     EXPECT_EQ(joint_names_[i], state->joint_names[i]);
+//   }
+
+//   // No trajectory by default, no desired state or error
+//   EXPECT_TRUE(state->desired.positions.empty());
+//   EXPECT_TRUE(state->desired.velocities.empty());
+//   EXPECT_TRUE(state->desired.accelerations.empty());
+
+//   EXPECT_EQ(n_joints, state->actual.positions.size());
+//   if (
+//     std::find(state_interface_types_.begin(), state_interface_types_.end(), "velocity") ==
+//     state_interface_types_.end())
+//   {
+//     EXPECT_TRUE(state->actual.velocities.empty());
+//   }
+//   else
+//   {
+//     EXPECT_EQ(n_joints, state->actual.velocities.size());
+//   }
+//   if (
+//     std::find(state_interface_types_.begin(), state_interface_types_.end(), "acceleration") ==
+//     state_interface_types_.end())
+//   {
+//     EXPECT_TRUE(state->actual.accelerations.empty());
+//   }
+//   else
+//   {
+//     EXPECT_EQ(n_joints, state->actual.accelerations.size());
+//   }
+
+//   EXPECT_TRUE(state->error.positions.empty());
+//   EXPECT_TRUE(state->error.velocities.empty());
+//   EXPECT_TRUE(state->error.accelerations.empty());
+// }
+
+// void TrajectoryControllerTest::test_state_publish_rate_target(int target_msg_count)
+// {
+//   rclcpp::Parameter state_publish_rate_param(
+//     "state_publish_rate", static_cast<double>(target_msg_count));
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(true, {state_publish_rate_param}, &executor);
+
+//   auto future_handle = std::async(std::launch::async, [&executor]() -> void { executor.spin(); });
+
+//   using control_msgs::msg::JointTrajectoryControllerState;
+
+//   const int qos_level = 10;
+//   int echo_received_counter = 0;
+//   rclcpp::Subscription<JointTrajectoryControllerState>::SharedPtr subs =
+//     traj_node_->create_subscription<JointTrajectoryControllerState>(
+//       controller_name_ + "/state", qos_level,
+//       [&](JointTrajectoryControllerState::UniquePtr) { ++echo_received_counter; });
+
+//   // update for 1second
+//   const auto start_time = rclcpp::Clock().now();
+//   const rclcpp::Duration wait = rclcpp::Duration::from_seconds(1.0);
+//   const auto end_time = start_time + wait;
+//   while (rclcpp::Clock().now() < end_time)
+//   {
+//     traj_controller_->update();
+//   }
+
+//   // We may miss the last message since time allowed is exactly the time needed
+//   EXPECT_NEAR(target_msg_count, echo_received_counter, 1);
+
+//   executor.cancel();
+// }
+
+// /**
+//  * @brief test_state_publish_rate Test that state publish rate matches configure rate
+//  */
+// TEST_P(TrajectoryControllerTestParameterized, test_state_publish_rate)
+// {
+//   test_state_publish_rate_target(10);
+// }
+
+// TEST_P(TrajectoryControllerTestParameterized, zero_state_publish_rate)
+// {
+//   test_state_publish_rate_target(0);
+// }
+
+// TEST_P(TrajectoryControllerTestParameterized, zero_state_publish_rate1)
+// {
+//   test_state_publish_rate_target(0);
+// }
+
+// TEST_P(TrajectoryControllerTestParameterized, test_states_values_are_properly_initialized)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(true, {}, &executor);
+
+//   auto future_handle = std::async(
+//     std::launch::async, [&executor]() -> void {
+//       executor.spin();
+//     });
+
+//   using control_msgs::msg::JointTrajectoryControllerState;
+
+//   auto callback = [this](const JointTrajectoryControllerState::UniquePtr state) -> void
+//   {
+//     ASSERT_TRUE(!state->joint_names.empty());
+//     ASSERT_EQ(state->joint_names.size(), joint_names_.size());
+//     ASSERT_TRUE(std::equal(state->joint_names.begin(), state->joint_names.end(),
+//                            joint_names_.begin(), joint_names_.end()));
+
+//     auto check_state_field = [&](const auto & field) -> void
+//     {
+//       ASSERT_EQ(field.size(), joint_names_.size());
+//       for (auto i = 0ul; i < field.size(); ++i) {
+//         ASSERT_FALSE(std::isnan(field[i]));
+//       }
+//     };
+
+//     check_state_field(state->desired.positions);
+//     check_state_field(state->desired.velocities);
+//     check_state_field(state->desired.accelerations);
+
+//     check_state_field(state->actual.positions);
+//     check_state_field(state->error.positions);
+
+//     // check velocity
+//     if (std::find(
+//         state_interface_types_.begin(), state_interface_types_.end(),
+//         hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end())
+//     {
+//       check_state_field(state->actual.velocities);
+//       check_state_field(state->error.velocities);
+//     }
+
+//     // check acceleration
+//     if (std::find(
+//         state_interface_types_.begin(), state_interface_types_.end(),
+//         hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end())
+//     {
+//       check_state_field(state->actual.accelerations);
+//       check_state_field(state->error.accelerations);
+//     }
+//   };
+
+//   const int qos_level = 10;
+//   rclcpp::Subscription<JointTrajectoryControllerState>::SharedPtr subs =
+//     traj_node_->create_subscription<JointTrajectoryControllerState>(
+//     controller_name_ + "/state", qos_level, callback);
+
+//   executor.cancel();
+// }
+
+// /**
+//  * @brief test_jumbled_joint_order Test sending trajectories with a joint order different from internal controller order
+//  */
+// TEST_P(TrajectoryControllerTestParameterized, test_jumbled_joint_order)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(true, {}, &executor);
+//   {
+//     trajectory_msgs::msg::JointTrajectory traj_msg;
+//     const std::vector<std::string> jumbled_joint_names{
+//       joint_names_[1], joint_names_[2], joint_names_[0]};
+//     traj_msg.joint_names = jumbled_joint_names;
+//     traj_msg.header.stamp = rclcpp::Time(0);
+//     traj_msg.points.resize(1);
+
+//     traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
+//     traj_msg.points[0].positions.resize(3);
+//     traj_msg.points[0].positions[0] = 2.0;
+//     traj_msg.points[0].positions[1] = 3.0;
+//     traj_msg.points[0].positions[2] = 1.0;
+
+//     trajectory_publisher_->publish(traj_msg);
+//   }
+
+//   traj_controller_->wait_for_trajectory(executor);
+//   // update for 0.25 seconds
+//   // TODO(destogl): Make this time a bit shorter to increase stability on the CI?
+//   //                Currently COMMON_THRESHOLD is adjusted.
+//   updateController(rclcpp::Duration::from_seconds(0.25));
+
+//   EXPECT_NEAR(1.0, joint_pos_[0], COMMON_THRESHOLD);
+//   EXPECT_NEAR(2.0, joint_pos_[1], COMMON_THRESHOLD);
+//   EXPECT_NEAR(3.0, joint_pos_[2], COMMON_THRESHOLD);
+// }
+
+// /**
+//  * @brief test_partial_joint_list Test sending trajectories with a subset of the controlled joints
+//  */
+// TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list)
+// {
+//   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
+
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(true, {partial_joints_parameters}, &executor);
+
+//   const double initial_joint3_cmd = joint_pos_[2];
+//   trajectory_msgs::msg::JointTrajectory traj_msg;
+
+//   {
+//     std::vector<std::string> partial_joint_names{joint_names_[1], joint_names_[0]};
+//     traj_msg.joint_names = partial_joint_names;
+//     traj_msg.header.stamp = rclcpp::Time(0);
+//     traj_msg.points.resize(1);
+
+//     traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
+//     traj_msg.points[0].positions.resize(2);
+//     traj_msg.points[0].positions[0] = 2.0;
+//     traj_msg.points[0].positions[1] = 1.0;
+//     traj_msg.points[0].velocities.resize(2);
+//     traj_msg.points[0].velocities[0] = 2.0;
+//     traj_msg.points[0].velocities[1] = 1.0;
+
+//     trajectory_publisher_->publish(traj_msg);
+//   }
+
+//   traj_controller_->wait_for_trajectory(executor);
+//   // update for 0.5 seconds
+//   updateController(rclcpp::Duration::from_seconds(0.25));
+
+//   double threshold = 0.001;
+//   EXPECT_NEAR(traj_msg.points[0].positions[1], joint_pos_[0], threshold);
+//   EXPECT_NEAR(traj_msg.points[0].positions[0], joint_pos_[1], threshold);
+//   EXPECT_NEAR(initial_joint3_cmd, joint_pos_[2], threshold)
+//     << "Joint 3 command should be current position";
+
+//   if (
+//     std::find(command_interface_types_.begin(), command_interface_types_.end(), "velocity") !=
+//     command_interface_types_.end())
+//   {
+//     // TODO(anyone): need help here - we should at least estimate the sign of the velocity
+//     //     EXPECT_NEAR(traj_msg.points[0].velocities[1], joint_vel_[0], threshold);
+//     //     EXPECT_NEAR(traj_msg.points[0].velocities[0], joint_vel_[1], threshold);
+//     EXPECT_NEAR(0.0, joint_vel_[2], threshold)
+//       << "Joint 3 velocity should be 0.0 since it's not in the goal";
+//   }
+//   // TODO(anyone): add here ckecks for acceleration commands
+
+//   executor.cancel();
+// }
+
+// /**
+//  * @brief test_partial_joint_list Test sending trajectories with a subset of the controlled joints without allow_partial_joints_goal
+//  */
+// TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list_not_allowed)
+// {
+//   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", false);
+
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(true, {partial_joints_parameters}, &executor);
+
+//   const double initial_joint1_cmd = joint_pos_[0];
+//   const double initial_joint2_cmd = joint_pos_[1];
+//   const double initial_joint3_cmd = joint_pos_[2];
+//   const double initial_joint_vel = 0.0;
+//   const double initial_joint_acc = 0.0;
+//   trajectory_msgs::msg::JointTrajectory traj_msg;
+
+//   {
+//     std::vector<std::string> partial_joint_names{joint_names_[1], joint_names_[0]};
+//     traj_msg.joint_names = partial_joint_names;
+//     traj_msg.header.stamp = rclcpp::Time(0);
+//     traj_msg.points.resize(1);
+
+//     traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
+//     traj_msg.points[0].positions.resize(2);
+//     traj_msg.points[0].positions[0] = 2.0;
+//     traj_msg.points[0].positions[1] = 1.0;
+//     traj_msg.points[0].velocities.resize(2);
+//     traj_msg.points[0].velocities[0] = 2.0;
+//     traj_msg.points[0].velocities[1] = 1.0;
+
+//     trajectory_publisher_->publish(traj_msg);
+//   }
+
+//   traj_controller_->wait_for_trajectory(executor);
+//   // update for 0.5 seconds
+//   updateController(rclcpp::Duration::from_seconds(0.25));
+
+//   double threshold = 0.001;
+//   EXPECT_NEAR(initial_joint1_cmd, joint_pos_[0], threshold)
+//     << "All joints command should be current position because goal was rejected";
+//   EXPECT_NEAR(initial_joint2_cmd, joint_pos_[1], threshold)
+//     << "All joints command should be current position because goal was rejected";
+//   EXPECT_NEAR(initial_joint3_cmd, joint_pos_[2], threshold)
+//     << "All joints command should be current position because goal was rejected";
+
+//   if (
+//     std::find(command_interface_types_.begin(), command_interface_types_.end(), "velocity") !=
+//     command_interface_types_.end())
+//   {
+//     EXPECT_NEAR(initial_joint_vel, joint_vel_[0], threshold)
+//       << "All joints velocities should be 0.0 because goal was rejected";
+//     EXPECT_NEAR(initial_joint_vel, joint_vel_[1], threshold)
+//       << "All joints velocities should be 0.0 because goal was rejected";
+//     EXPECT_NEAR(initial_joint_vel, joint_vel_[2], threshold)
+//       << "All joints velocities should be 0.0 because goal was rejected";
+//   }
+
+//   if (
+//     std::find(command_interface_types_.begin(), command_interface_types_.end(), "acceleration") !=
+//     command_interface_types_.end())
+//   {
+//     EXPECT_NEAR(initial_joint_acc, joint_acc_[0], threshold)
+//       << "All joints accelerations should be 0.0 because goal was rejected";
+//     EXPECT_NEAR(initial_joint_acc, joint_acc_[1], threshold)
+//       << "All joints accelerations should be 0.0 because goal was rejected";
+//     EXPECT_NEAR(initial_joint_acc, joint_acc_[2], threshold)
+//       << "All joints accelerations should be 0.0 because goal was rejected";
+//   }
+
+//   executor.cancel();
+// }
+
+// /**
+//  * @brief invalid_message Test mismatched joint and reference vector sizes
+//  */
+// TEST_P(TrajectoryControllerTestParameterized, invalid_message)
+// {
+//   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", false);
+//   rclcpp::Parameter allow_integration_parameters("allow_integration_in_goal_trajectories", false);
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(
+//     true, {partial_joints_parameters, allow_integration_parameters}, &executor);
+
+//   trajectory_msgs::msg::JointTrajectory traj_msg, good_traj_msg;
+
+//   good_traj_msg.joint_names = joint_names_;
+//   good_traj_msg.header.stamp = rclcpp::Time(0);
+//   good_traj_msg.points.resize(1);
+//   good_traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
+//   good_traj_msg.points[0].positions.resize(1);
+//   good_traj_msg.points[0].positions = {1.0, 2.0, 3.0};
+//   good_traj_msg.points[0].velocities.resize(1);
+//   good_traj_msg.points[0].velocities = {-1.0, -2.0, -3.0};
+//   EXPECT_TRUE(traj_controller_->validate_trajectory_msg(good_traj_msg));
+
+//   // Incompatible joint names
+//   traj_msg = good_traj_msg;
+//   traj_msg.joint_names = {"bad_name"};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // No position data
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].positions.clear();
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Incompatible data sizes, too few positions
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].positions = {1.0, 2.0};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Incompatible data sizes, too many positions
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].positions = {1.0, 2.0, 3.0, 4.0};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Incompatible data sizes, too few velocities
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].velocities = {1.0, 2.0};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Incompatible data sizes, too few accelerations
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].accelerations = {1.0, 2.0};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Incompatible data sizes, too few efforts
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].positions.clear();
+//   traj_msg.points[0].effort = {1.0, 2.0};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Non-strictly increasing waypoint times
+//   traj_msg = good_traj_msg;
+//   traj_msg.points.push_back(traj_msg.points.front());
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+// }
+
+// /// With allow_integration_in_goal_trajectories parameter trajectory missing position or velocities
+// /// are accepted
+// TEST_P(TrajectoryControllerTestParameterized, missing_positions_message_accepted)
+// {
+//   rclcpp::Parameter allow_integration_parameters("allow_integration_in_goal_trajectories", true);
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(true, {allow_integration_parameters}, &executor);
+
+//   trajectory_msgs::msg::JointTrajectory traj_msg, good_traj_msg;
+
+//   good_traj_msg.joint_names = joint_names_;
+//   good_traj_msg.header.stamp = rclcpp::Time(0);
+//   good_traj_msg.points.resize(1);
+//   good_traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
+//   good_traj_msg.points[0].positions.resize(1);
+//   good_traj_msg.points[0].positions = {1.0, 2.0, 3.0};
+//   good_traj_msg.points[0].velocities.resize(1);
+//   good_traj_msg.points[0].velocities = {-1.0, -2.0, -3.0};
+//   good_traj_msg.points[0].accelerations.resize(1);
+//   good_traj_msg.points[0].accelerations = {1.0, 2.0, 3.0};
+//   EXPECT_TRUE(traj_controller_->validate_trajectory_msg(good_traj_msg));
+
+//   // No position data
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].positions.clear();
+//   EXPECT_TRUE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // No position and velocity data
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].positions.clear();
+//   traj_msg.points[0].velocities.clear();
+//   EXPECT_TRUE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // All empty
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].positions.clear();
+//   traj_msg.points[0].velocities.clear();
+//   traj_msg.points[0].accelerations.clear();
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Incompatible data sizes, too few positions
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].positions = {1.0, 2.0};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Incompatible data sizes, too many positions
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].positions = {1.0, 2.0, 3.0, 4.0};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Incompatible data sizes, too few velocities
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].velocities = {1.0};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+//   // Incompatible data sizes, too few accelerations
+//   traj_msg = good_traj_msg;
+//   traj_msg.points[0].accelerations = {2.0};
+//   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+// }
+
+// /**
+//  * @brief test_trajectory_replace Test replacing an existing trajectory
+//  */
+// TEST_P(TrajectoryControllerTestParameterized, test_trajectory_replace)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
+//   SetUpAndActivateTrajectoryController(true, {partial_joints_parameters}, &executor);
+
+//   subscribeToState();
+
+//   std::vector<std::vector<double>> points_old{{{2., 3., 4.}}};
+//   std::vector<std::vector<double>> points_partial_new{{1.5}};
+
+//   const auto delay = std::chrono::milliseconds(500);
+//   builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(delay)};
+//   publish(time_from_start, points_old);
+//   trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
+//   expected_actual.positions = {points_old[0].begin(), points_old[0].end()};
+//   expected_desired.positions = {points_old[0].begin(), points_old[0].end()};
+//   //  Check that we reached end of points_old trajectory
+//   // Denis: delta was 0.1 with 0.2 works for me
+//   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.2);
+
+//   RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory");
+//   publish(time_from_start, points_partial_new);
+//   // Replaced trajectory is a mix of previous and current goal
+//   expected_desired.positions[0] = points_partial_new[0][0];
+//   expected_desired.positions[1] = points_old[0][1];
+//   expected_desired.positions[2] = points_old[0][2];
+//   expected_actual = expected_desired;
+//   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
+// }
+
+// /**
+//  * @brief test_ignore_old_trajectory Sending an old trajectory replacing an existing trajectory
+//  */
+// TEST_P(TrajectoryControllerTestParameterized, test_ignore_old_trajectory)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(true, {}, &executor);
+//   subscribeToState();
+
+//   // TODO(anyone): add expectations for velocities and accelerations
+//   std::vector<std::vector<double>> points_old{{{2., 3., 4.}, {4., 5., 6.}}};
+//   std::vector<std::vector<double>> points_new{{{-1., -2., -3.}}};
+
+//   const auto delay = std::chrono::milliseconds(500);
+//   builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(delay)};
+//   publish(time_from_start, points_old);
+//   trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
+//   expected_actual.positions = {points_old[0].begin(), points_old[0].end()};
+//   expected_desired = expected_actual;
+//   //  Check that we reached end of points_old[0] trajectory
+//   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
+
+//   RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory in the past");
+//   //  New trajectory will end before current time
+//   rclcpp::Time new_traj_start = rclcpp::Clock().now() - delay - std::chrono::milliseconds(100);
+//   expected_actual.positions = {points_old[1].begin(), points_old[1].end()};
+//   expected_desired = expected_actual;
+//   publish(time_from_start, points_new, new_traj_start);
+//   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
+// }
+
+// TEST_P(TrajectoryControllerTestParameterized, test_ignore_partial_old_trajectory)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   SetUpAndActivateTrajectoryController(true, {}, &executor);
+//   subscribeToState();
+
+//   std::vector<std::vector<double>> points_old{{{2., 3., 4.}, {4., 5., 6.}}};
+//   std::vector<std::vector<double>> points_new{{{-1., -2., -3.}, {-2., -4., -6.}}};
+
+//   const auto delay = std::chrono::milliseconds(500);
+//   builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(delay)};
+//   publish(time_from_start, points_old);
+//   trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
+//   expected_actual.positions = {points_old[0].begin(), points_old[0].end()};
+//   expected_desired = expected_actual;
+//   //  Check that we reached end of points_old[0]trajectory
+//   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
+
+//   RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory partially in the past");
+//   //  New trajectory first point is in the past, second is in the future
+//   rclcpp::Time new_traj_start = rclcpp::Clock().now() - delay - std::chrono::milliseconds(100);
+//   expected_actual.positions = {points_new[1].begin(), points_new[1].end()};
+//   expected_desired = expected_actual;
+//   publish(time_from_start, points_new, new_traj_start);
+//   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
+// }
+
+// TEST_P(TrajectoryControllerTestParameterized, test_execute_partial_traj_in_future)
+// {
+//   SetUpTrajectoryController();
+//   auto traj_node = traj_controller_->get_node();
+//   RCLCPP_WARN(
+//     traj_node->get_logger(),
+//     "Test disabled until current_trajectory is taken into account when adding a new trajectory.");
+//   // https://github.com/ros-controls/ros_controllers/blob/melodic-devel/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h#L149
+//   return;
+
+//   // TODO(anyone): use SetUpAndActivateTrajectoryController method instead of the next line
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   executor.add_node(traj_node->get_node_base_interface());
+//   subscribeToState();
+//   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
+//   traj_node->set_parameter(partial_joints_parameters);
+//   traj_controller_->configure();
+//   traj_controller_->activate();
+
+//   std::vector<std::vector<double>> full_traj{{{2., 3., 4.}, {4., 6., 8.}}};
+//   std::vector<std::vector<double>> partial_traj{
+//     {{-1., -2.},
+//      {
+//        -2.,
+//        -4,
+//      }}};
+//   const auto delay = std::chrono::milliseconds(500);
+//   builtin_interfaces::msg::Duration points_delay{rclcpp::Duration(delay)};
+//   // Send full trajectory
+//   publish(points_delay, full_traj);
+//   // Sleep until first waypoint of full trajectory
+
+//   trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
+//   expected_actual.positions = {full_traj[0].begin(), full_traj[0].end()};
+//   expected_desired = expected_actual;
+//   //  Check that we reached end of points_old[0]trajectory and are starting points_old[1]
+//   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
+
+//   // Send partial trajectory starting after full trajecotry is complete
+//   RCLCPP_INFO(traj_node->get_logger(), "Sending new trajectory in the future");
+//   publish(points_delay, partial_traj, rclcpp::Clock().now() + delay * 2);
+//   // Wait until the end start and end of partial traj
+
+//   expected_actual.positions = {partial_traj.back()[0], partial_traj.back()[1], full_traj.back()[2]};
+//   expected_desired = expected_actual;
+
+//   waitAndCompareState(
+//     expected_actual, expected_desired, executor, rclcpp::Duration(delay * (2 + 2)), 0.1);
+// }
+
+// TEST_P(TrajectoryControllerTestParameterized, test_jump_when_state_tracking_error_updated)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   // default if false so it will not be actually set parameter
+//   rclcpp::Parameter is_open_loop_parameters("open_loop_control", false);
+//   SetUpAndActivateTrajectoryController(true, {is_open_loop_parameters}, &executor, true);
+
+//   // goal setup
+//   std::vector<double> first_goal = {3.3, 4.4, 5.5};
+//   std::vector<double> second_goal = {6.6, 8.8, 11.0};
+//   double state_from_command_offset = 0.3;
+
+//   // send msg
+//   builtin_interfaces::msg::Duration time_from_start;
+//   time_from_start.sec = 1;
+//   time_from_start.nanosec = 0;
+//   std::vector<std::vector<double>> points{{first_goal}};
+//   publish(time_from_start, points);
+//   traj_controller_->wait_for_trajectory(executor);
+//   updateController(rclcpp::Duration::from_seconds(1.1));
+
+//   // JTC is executing trajectory in open-loop therefore:
+//   // - internal state does not have to be updated (in this test-case it shouldn't)
+//   // - internal command is updated
+//   EXPECT_NEAR(INITIAL_POS_JOINT1, joint_state_pos_[0], COMMON_THRESHOLD);
+//   EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+
+//   // State interface should have offset from the command before starting a new trajectory
+//   joint_state_pos_[0] = first_goal[0] - state_from_command_offset;
+
+//   // Move joint further in the same direction as before (to the second goal)
+//   points = {{second_goal}};
+//   publish(time_from_start, points);
+//   traj_controller_->wait_for_trajectory(executor);
+
+//   // One the first update(s) there should be a "jump" in opposite direction from command
+//   // (towards the state value)
+//   EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+//   traj_controller_->update();
+//   // Expect backward commands at first
+//   EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
+//   EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
+//   EXPECT_LT(joint_pos_[0], first_goal[0]);
+//   traj_controller_->update();
+//   EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
+//   EXPECT_LT(joint_pos_[0], first_goal[0]);
+//   traj_controller_->update();
+//   EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
+//   EXPECT_LT(joint_pos_[0], first_goal[0]);
+
+//   // Finally the second goal will be commanded/reached
+//   updateController(rclcpp::Duration::from_seconds(1.1));
+//   EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+
+//   // State interface should have offset from the command before starting a new trajectory
+//   joint_state_pos_[0] = second_goal[0] - state_from_command_offset;
+
+//   // Move joint back to the first goal
+//   points = {{first_goal}};
+//   publish(time_from_start, points);
+//   traj_controller_->wait_for_trajectory(executor);
+
+//   // One the first update(s) there should be a "jump" in the goal direction from command
+//   // (towards the state value)
+//   EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+//   traj_controller_->update();
+//   // Expect backward commands at first
+//   EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
+//   EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
+//   EXPECT_GT(joint_pos_[0], first_goal[0]);
+//   traj_controller_->update();
+//   EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
+//   EXPECT_GT(joint_pos_[0], first_goal[0]);
+//   traj_controller_->update();
+//   EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
+//   EXPECT_GT(joint_pos_[0], first_goal[0]);
+
+//   // Finally the first goal will be commanded/reached
+//   updateController(rclcpp::Duration::from_seconds(1.1));
+//   EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+
+//   executor.cancel();
+// }
+
+// TEST_P(
+//   TrajectoryControllerTestParameterized, test_no_jump_when_state_tracking_error_not_updated)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   // default if false so it will not be actually set parameter
+//   rclcpp::Parameter is_open_loop_parameters("open_loop_control", true);
+//   SetUpAndActivateTrajectoryController(true, {is_open_loop_parameters}, &executor, true);
+
+//   // goal setup
+//   std::vector<double> first_goal = {3.3, 4.4, 5.5};
+//   std::vector<double> second_goal = {6.6, 8.8, 11.0};
+//   double state_from_command_offset = 0.3;
+
+//   // send msg
+//   builtin_interfaces::msg::Duration time_from_start;
+//   time_from_start.sec = 1;
+//   time_from_start.nanosec = 0;
+//   std::vector<std::vector<double>> points {{first_goal}};
+//   publish(time_from_start, points);
+//   traj_controller_->wait_for_trajectory(executor);
+//   updateController(rclcpp::Duration::from_seconds(1.1));
+
+//   // JTC is executing trajectory in open-loop therefore:
+//   // - internal state does not have to be updated (in this test-case it shouldn't)
+//   // - internal command is updated
+//   EXPECT_NEAR(INITIAL_POS_JOINT1, joint_state_pos_[0], COMMON_THRESHOLD);
+//   EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+
+//   // State interface should have offset from the command before starting a new trajectory
+//   joint_state_pos_[0] = first_goal[0] - state_from_command_offset;
+
+//   // Move joint further in the same direction as before (to the second goal)
+//   points = {{second_goal}};
+//   publish(time_from_start, points);
+//   traj_controller_->wait_for_trajectory(executor);
+
+//   // One the first update(s) there **should not** be a "jump" in opposite direction from command
+//   // (towards the state value)
+//   EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+//   traj_controller_->update();
+//   // There should not be backward commands
+//   EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+//   EXPECT_GT(joint_pos_[0], first_goal[0]);
+//   EXPECT_LT(joint_pos_[0], second_goal[0]);
+//   traj_controller_->update();
+//   EXPECT_GT(joint_pos_[0], first_goal[0]);
+//   EXPECT_LT(joint_pos_[0], second_goal[0]);
+//   traj_controller_->update();
+//   EXPECT_GT(joint_pos_[0], first_goal[0]);
+//   EXPECT_LT(joint_pos_[0], second_goal[0]);
+
+//   // Finally the second goal will be commanded/reached
+//   updateController(rclcpp::Duration::from_seconds(1.1));
+//   EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+
+//   // State interface should have offset from the command before starting a new trajectory
+//   joint_state_pos_[0] = second_goal[0] - state_from_command_offset;
+
+//   // Move joint back to the first goal
+//   points = {{first_goal}};
+//   publish(time_from_start, points);
+//   traj_controller_->wait_for_trajectory(executor);
+
+//   // One the first update(s) there **should not** be a "jump" in the goal direction from command
+//   // (towards the state value)
+//   EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+//   traj_controller_->update();
+//   // There should not be a jump toward commands
+//   EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+//   EXPECT_LT(joint_pos_[0], second_goal[0]);
+//   EXPECT_GT(joint_pos_[0], first_goal[0]);
+//   traj_controller_->update();
+//   EXPECT_GT(joint_pos_[0], first_goal[0]);
+//   EXPECT_LT(joint_pos_[0], second_goal[0]);
+//   traj_controller_->update();
+//   EXPECT_GT(joint_pos_[0], first_goal[0]);
+//   EXPECT_LT(joint_pos_[0], second_goal[0]);
+
+//   // Finally the first goal will be commanded/reached
+//   updateController(rclcpp::Duration::from_seconds(1.1));
+//   EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+
+//   executor.cancel();
+// }
+
+// // Testing that values are read from state interfaces when hardware is started for the first
+// // time and hardware state has offset --> this is indicated by NaN values in state interfaces
+// TEST_P(
+//   TrajectoryControllerTestParameterized, test_hw_states_has_offset_first_controller_start)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   // default if false so it will not be actually set parameter
+//   rclcpp::Parameter is_open_loop_parameters("open_loop_control", true);
+
+//   // set command values to NaN
+//   for (auto i = 0u; i < 3; ++i) {
+//     joint_pos_[i] = std::numeric_limits<double>::quiet_NaN();
+//     joint_vel_[i] = std::numeric_limits<double>::quiet_NaN();
+//     joint_acc_[i] = std::numeric_limits<double>::quiet_NaN();
+//   }
+//   SetUpAndActivateTrajectoryController(true, {is_open_loop_parameters}, &executor, true);
+
+//   auto current_state_when_offset = traj_controller_->get_current_state_when_offset();
+
+//   for (auto i = 0u; i < 3; ++i) {
+//     EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
+
+//     // check velocity
+//     if (std::find(
+//         state_interface_types_.begin(), state_interface_types_.end(),
+//         hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end() &&
+//       std::find(
+//         command_interface_types_.begin(), command_interface_types_.end(),
+//         hardware_interface::HW_IF_VELOCITY) != command_interface_types_.end())
+//     {
+//       EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
+//     }
+
+//     // check acceleration
+//     if (std::find(
+//         state_interface_types_.begin(), state_interface_types_.end(),
+//         hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end() &&
+//       std::find(
+//         command_interface_types_.begin(), command_interface_types_.end(),
+//         hardware_interface::HW_IF_ACCELERATION) != command_interface_types_.end())
+//     {
+//       EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
+//     }
+//   }
+
+//   executor.cancel();
+// }
+
+// // Testing that values are read from state interfaces when hardware is started after some values
+// // are set on the hardware commands
+// TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_controller_start)
+// {
+//   rclcpp::executors::SingleThreadedExecutor executor;
+//   // default if false so it will not be actually set parameter
+//   rclcpp::Parameter is_open_loop_parameters("open_loop_control", true);
+
+//   // set command values to NaN
+//   for (auto i = 0u; i < 3; ++i)
+//   {
+//     joint_pos_[i] = 3.1 + i;
+//     joint_vel_[i] = 0.25 + i;
+//     joint_acc_[i] = 0.02 + i / 10.0;
+//   }
+//   SetUpAndActivateTrajectoryController(true, {is_open_loop_parameters}, &executor, true);
+
+//   auto current_state_when_offset = traj_controller_->get_current_state_when_offset();
+
+//   for (auto i = 0u; i < 3; ++i)
+//   {
+//     EXPECT_EQ(current_state_when_offset.positions[i], joint_pos_[i]);
+
+//     // check velocity
+//     if (
+//       std::find(
+//         state_interface_types_.begin(), state_interface_types_.end(),
+//         hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end() &&
+//       std::find(
+//         command_interface_types_.begin(), command_interface_types_.end(),
+//         hardware_interface::HW_IF_VELOCITY) != command_interface_types_.end())
+//     {
+//       EXPECT_EQ(current_state_when_offset.positions[i], joint_pos_[i]);
+//     }
+
+//     // check acceleration
+//     if (
+//       std::find(
+//         state_interface_types_.begin(), state_interface_types_.end(),
+//         hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end() &&
+//       std::find(
+//         command_interface_types_.begin(), command_interface_types_.end(),
+//         hardware_interface::HW_IF_ACCELERATION) != command_interface_types_.end())
+//     {
+//       EXPECT_EQ(current_state_when_offset.positions[i], joint_pos_[i]);
+//     }
+//   }
+
+//   executor.cancel();
+// }
+
+// // position controllers
+// INSTANTIATE_TEST_SUITE_P(
+//   PositionTrajectoryControllers,
+//   TrajectoryControllerTestParameterized,
+//   ::testing::Values(
+//     std::make_tuple(std::vector<std::string>({"position"}), std::vector<std::string>({"position"})),
+//     std::make_tuple(
+//       std::vector<std::string>({"position"}), std::vector<std::string>({"position", "velocity"})),
+//     std::make_tuple(
+//       std::vector<std::string>({"position"}),
+//       std::vector<std::string>({"position", "velocity", "acceleration"}))));
+
+// // position_velocity controllers
+// INSTANTIATE_TEST_SUITE_P(
+//   PositionVelocityTrajectoryControllers,
+//   TrajectoryControllerTestParameterized,
+//   ::testing::Values(
+//     std::make_tuple(
+//       std::vector<std::string>({"position", "velocity"}), std::vector<std::string>({"position"})),
+//     std::make_tuple(
+//       std::vector<std::string>({"position", "velocity"}),
+//       std::vector<std::string>({"position", "velocity"})),
+//     std::make_tuple(
+//       std::vector<std::string>({"position", "velocity"}),
+//       std::vector<std::string>({"position", "velocity", "acceleration"}))));
+
+// // position_velocity_acceleration controllers
+// INSTANTIATE_TEST_SUITE_P(
+//   PositionVelocityAccelerationTrajectoryControllers,
+//   TrajectoryControllerTestParameterized,
+//   ::testing::Values(
+//     std::make_tuple(
+//       std::vector<std::string>({"position", "velocity", "acceleration"}),
+//       std::vector<std::string>({"position"})),
+//     std::make_tuple(
+//       std::vector<std::string>({"position", "velocity", "acceleration"}),
+//       std::vector<std::string>({"position", "velocity"})),
+//     std::make_tuple(
+//       std::vector<std::string>({"position", "velocity", "acceleration"}),
+//       std::vector<std::string>({"position", "velocity", "acceleration"}))));
+
+// TEST_F(TrajectoryControllerTest, incorrect_initialization_using_interface_parameters)
+// {
+//   auto set_parameter_and_check_result = [&]() {
+//     EXPECT_EQ(traj_controller_->get_state().id(), State::PRIMARY_STATE_UNCONFIGURED);
+//     SetParameters();  // This call is replacing the way parameters are set via launch
+//     traj_controller_->configure();
+//     EXPECT_EQ(traj_controller_->get_state().id(), State::PRIMARY_STATE_UNCONFIGURED);
+//   };
+
+//   SetUpTrajectoryController(false);
+
+//   // command interfaces: empty
+//   command_interface_types_ = {};
+//   set_parameter_and_check_result();
+
+//   // command interfaces: bad_name
+//   command_interface_types_ = {"bad_name"};
+//   set_parameter_and_check_result();
+
+//   // command interfaces: effort not yet implemented
+//   command_interface_types_ = {"effort"};
+//   set_parameter_and_check_result();
+
+//   // command interfaces: effort has to be only
+//   command_interface_types_ = {"effort", "position"};
+//   set_parameter_and_check_result();
+
+//   // command interfaces: velocity alone not yet implemented
+//   command_interface_types_ = {"velocity"};
+//   set_parameter_and_check_result();
+
+//   // command interfaces: velocity - position not present
+//   command_interface_types_ = {"velocity", "acceleration"};
+//   set_parameter_and_check_result();
+
+//   // command interfaces: acceleration without position and velocity
+//   command_interface_types_ = {"acceleration"};
+//   set_parameter_and_check_result();
+
+//   // state interfaces: empty
+//   state_interface_types_ = {};
+//   set_parameter_and_check_result();
+
+//   // state interfaces: cannot not be effort
+//   state_interface_types_ = {"effort"};
+//   set_parameter_and_check_result();
+
+//   // state interfaces: bad name
+//   state_interface_types_ = {"bad_name"};
+//   set_parameter_and_check_result();
+
+//   // state interfaces: velocity - position not present
+//   state_interface_types_ = {"velocity"};
+//   set_parameter_and_check_result();
+//   state_interface_types_ = {"velocity", "acceleration"};
+//   set_parameter_and_check_result();
+
+//   // state interfaces: acceleration without position and velocity
+//   state_interface_types_ = {"acceleration"};
+//   set_parameter_and_check_result();
+// }


### PR DESCRIPTION
Add new file trajectory_execution_impl.hpp, which is responsible for:
- setting up and managing a control_msgs::action::FollowJointTrajectory action server
- checking/managing the current Trajectory 
- in general, any sort of manipulation/validation of JointTrajectory messages

The idea is to pull out this common functionality from JointTrajectoryController so that it can be easily repurposed in other controllers want to handle JointTrajectory messages.

For future thought, we could potentially add new functions or comments to ControllerInterface to make it more clear the typical steps done in the update() function.